### PR TITLE
Replace invalid scoped package name characters

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -359,6 +359,12 @@ module.exports = function (data, callback) {
           `Changing ${options.version} to ${adjustedVersion}`)
         options.version = adjustedVersion
       }
+      const adjustedName = util.replaceScopeNameCharacters(options.name)
+      if (adjustedName !== options.name) {
+        data.logger('Warning: replacing scoped package name to comply with guidelines for naming packages.' +
+          `Changing ${options.name} to ${adjustedName}`)
+        options.version = adjustedName
+      }
       return data.logger(`Creating package with options\n${JSON.stringify(options, null, 2)}`)
     })
     .then(() => createDir(options))

--- a/src/util.js
+++ b/src/util.js
@@ -27,7 +27,16 @@ function replaceInvalidVersionCharacters (version) {
   return version.replace(/[-]/g, '.')
 }
 
+/**
+ * Returns a string containing only characters that are allowed as a name of an .rpm file
+ */
+function replaceScopeNameCharacters (name) {
+  name = name || ''
+  return name.replace(/^@/, '').replace(/\//, '_')
+}
+
 module.exports = {
   getHomePage: getHomePage,
-  replaceInvalidVersionCharacters: replaceInvalidVersionCharacters
+  replaceInvalidVersionCharacters: replaceInvalidVersionCharacters,
+  replaceScopeNameCharacters: replaceScopeNameCharacters
 }

--- a/test/util.js
+++ b/test/util.js
@@ -59,4 +59,21 @@ describe('private utility functions', function () {
       })
     })
   })
+
+  describe('replaceScopeNameCharacters', function (test) {
+    [
+      {
+        input: 'poopie',
+        expectedOutput: 'poopie'
+      },
+      {
+        input: '@poopie/core',
+        expectedOutput: 'poopie_core'
+      }
+    ].forEach(scenario => {
+      it(`${JSON.stringify(scenario.input)} -> ${JSON.stringify(scenario.expectedOutput)}`, () => {
+        expect(util.replaceScopeNameCharacters(scenario.input)).to.equal(scenario.expectedOutput)
+      })
+    })
+  })
 })


### PR DESCRIPTION
Fixes #81 

We should also implement this on `-debian` and `-windows` now that scoped packages are a thing.
The only difference is that `-debian` will replace `/` for `-` rather than the underscore used here, due to different naming conventions between `.deb` and `.rpm`. For `-windows`, we should replace with an underscore, same as `redhat`.