### PR TITLE
Apped user options.requires and remove duplicates

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -81,6 +81,13 @@ function getOptions (data, defaults) {
   // `description-line-too-long`.
   options.productDescription = wrap(options.productDescription, {width: 80, indent: ''})
 
+  // Create array with unique values from default & user-supplied dependencies
+  if (data.options) { // options passed programmatically
+    options.requires = _.union(defaults.requires, data.options.requires)
+  } else { // options passed via command-line
+    options.requires = _.union(defaults.requires, data.requires)
+  }
+
   // Scan if there are any installation scripts and adds them to the options
   return generateScripts(options)
 }

--- a/src/installer.js
+++ b/src/installer.js
@@ -68,6 +68,15 @@ function getOptions (data, defaults) {
   // Flatten everything for ease of use.
   const options = _.defaults({}, data, data.options, defaults)
 
+  if (!options.description && !options.productDescription) {
+    throw new Error(`No Description or ProductDescription provided. Please set either a description in the app's package.json or provide it in the options.`)
+  }
+
+  if (options.description) {
+    // Do not end with a period
+    options.description = options.description.replace(/\.*$/, '')
+  }
+
   // Wrap the extended description to avoid rpmlint warning about
   // `description-line-too-long`.
   options.productDescription = wrap(options.productDescription, {width: 80, indent: ''})

--- a/src/installer.js
+++ b/src/installer.js
@@ -70,7 +70,7 @@ function getOptions (data, defaults) {
 
   // Wrap the extended description to avoid rpmlint warning about
   // `description-line-too-long`.
-  options.productDescription = wrap(options.productDescription, {width: 100, indent: ''})
+  options.productDescription = wrap(options.productDescription, {width: 80, indent: ''})
 
   // Scan if there are any installation scripts and adds them to the options
   return generateScripts(options)

--- a/test/helpers/dependencies.js
+++ b/test/helpers/dependencies.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const _ = require('lodash')
+const { exec } = require('mz/child_process')
+
+// Default options (partly from src/installer.js)
+// TODO: Replace this with electron-installer-common.dependencies
+const defaultsRequires = [
+  'lsb',
+  'libXScrnSaver'
+]
+
+module.exports = {
+  assertDependenciesEqual: function assertDependenciesEqual (outputDir, rpmFilename, userDependencies) {
+    return exec(`rpm -qp --requires ${rpmFilename}`, { cwd: outputDir })
+      .then(stdout => {
+        const baseDependencies = _.union(defaultsRequires, userDependencies.requires).sort() // Array with both user and default dependencies based on src/installer.js
+
+        // Array of generated dependencies
+        const destRequires = stdout[0]
+          .split(/\n/)
+          .filter(el => el !== '') // removes any empty strings from the array
+          .filter(el => el.match(/^rpmlib\(/) === null) // removes rpmlib dependencies
+          .sort()
+
+        if (!_.isEqual(baseDependencies, destRequires)) {
+          throw new Error('There are duplicate dependencies')
+        }
+
+        return Promise.resolve()
+      })
+  }
+}

--- a/test/installer.js
+++ b/test/installer.js
@@ -7,6 +7,7 @@ const installer = require('..')
 
 const { exec } = require('mz/child_process')
 const access = require('./helpers/access')
+const dependencies = require('./helpers/dependencies')
 const describeInstaller = require('./helpers/describe_installer')
 const tempOutputDir = describeInstaller.tempOutputDir
 const testInstallerOptions = describeInstaller.testInstallerOptions
@@ -159,6 +160,26 @@ describe('module', function () {
             throw new Error('Did not use custom template')
           }
           return Promise.resolve()
+        })
+  )
+
+  describeInstaller(
+    'with duplicate dependencies',
+    {
+      src: 'test/fixtures/app-without-asar/',
+      options: {
+        requires: ['perl', 'dbus', 'dbus']
+      }
+    },
+    'removes duplicate dependencies',
+    outputDir =>
+      assertNonASARRpmExists(outputDir)
+        .then(() => {
+          return dependencies.assertDependenciesEqual(
+            outputDir,
+            'bartest.x86_64.rpm',
+            { requires: ['perl', 'dbus', 'dbus'] }
+          )
         })
   )
 })


### PR DESCRIPTION
This PR also fixes two small issues:

- All lines in the `%description` section (`options.productDescription`) of the spec file, must be 80 characters or less
- The `Summary:` section (`options.description`) of the spec file, should not end with a period