### PR TITLE
Specs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,12 +263,6 @@ Default: `package.license`
 
 License of the package, used in the [`License` field of the `spec` file](https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Creating_a_SPEC_file).
 
-#### options.group
-Type: `String`
-Default: `undefined`
-
-Group of the package, used in the [`Group` field of the `spec` file](https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Creating_a_SPEC_file).
-
 #### options.arch
 Type: `String`
 Default: `undefined`

--- a/README.md
+++ b/README.md
@@ -237,7 +237,8 @@ Generic name of the application (e.g. `Text Editor`), used in the [`GenericName`
 Type: `String`
 Default: `package.description`
 
-Short description of the application, used in the [`Summary` field of the `spec` file](https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Creating_a_SPEC_file).
+Short, one-line description of the application; do not end with a period.
+Used in the [`Summary` field of the `spec` file](https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Creating_a_SPEC_file).
 
 #### options.productDescription
 Type: `String`

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -4,7 +4,6 @@
 <% } %><% if (description) { %>Summary: <%= description %>
 <% } %><% if (homepage) { %>URL: <%= homepage %>
 <% } %><% if (license) { %>License: <%= license %>
-<% } %><% if (group) { %>Group: <%= group %>
 <% } %>
 AutoReqProv: no
 <% if (requires) { %>Requires: <%= requires.join(', ') %>

--- a/src/installer.js
+++ b/src/installer.js
@@ -29,7 +29,6 @@ const getDefaults = function (data) {
       return Object.assign(common.getDefaultsFromPackageJSON(pkg), {
         version: pkg.version || '0.0.0',
         license: pkg.license,
-        group: undefined,
         requires: [
           'lsb',
           'libXScrnSaver'

--- a/src/installer.js
+++ b/src/installer.js
@@ -68,6 +68,15 @@ function getOptions (data, defaults) {
   // Flatten everything for ease of use.
   const options = _.defaults({}, data, data.options, defaults)
 
+  if (!options.description && !options.productDescription) {
+    throw new Error(`No Description or ProductDescription provided. Please set either a description in the app's package.json or provide it in the options.`)
+  }
+
+  if (options.description) {
+    // Do not end with a period
+    options.description = options.description.replace(/\.*$/, '')
+  }
+
   // Wrap the extended description to avoid rpmlint warning about
   // `description-line-too-long`.
   options.productDescription = wrap(options.productDescription, {width: 80, indent: ''})

--- a/src/installer.js
+++ b/src/installer.js
@@ -70,7 +70,7 @@ function getOptions (data, defaults) {
 
   // Wrap the extended description to avoid rpmlint warning about
   // `description-line-too-long`.
-  options.productDescription = wrap(options.productDescription, {width: 100, indent: ''})
+  options.productDescription = wrap(options.productDescription, {width: 80, indent: ''})
 
   // Scan if there are any installation scripts and adds them to the options
   return generateScripts(options)


### PR DESCRIPTION
The PR fixes:

- Removes deprecated `options.groups`
- All lines in the _%description_ section (`options.productDescription`) of the spec file, must be 80 characters or less
- The _Summary:_ section (`options.description`) of the spec file, should not end with a period