### PR TITLE
Sanitize package names to conform to Fedora policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
-    "electron-installer-common": "^0.4.2",
+    "electron-installer-common": "^0.5.0",
     "fs-extra": "^5.0.0",
     "lodash": "^4.17.4",
     "nodeify": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,12 +34,10 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
-    "electron-installer-common": "^0.4.0",
+    "electron-installer-common": "^0.4.2",
     "fs-extra": "^5.0.0",
     "lodash": "^4.17.4",
     "nodeify": "^1.0.1",
-    "parse-author": "^2.0.0",
-    "tmp-promise": "^1.0.4",
     "word-wrap": "^1.2.3",
     "yargs": "11.0.0"
   },
@@ -54,6 +52,7 @@
     "mocha": "^5.0.4",
     "mz": "^2.7.0",
     "promise-retry": "^1.1.1",
-    "sinon": "^7.2.2"
+    "sinon": "^7.2.2",
+    "tmp-promise": "^1.0.4"
   }
 }

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const dependencies = require('electron-installer-common/src/dependencies')
+const common = require('electron-installer-common')
 const spawn = require('./spawn')
 
 const dependencyMap = {
@@ -43,7 +43,7 @@ function rpmVersionSupportsBooleanDependencies (rpmVersionString) {
  * Transforms the list of trash requires into an RPM boolean dependency list.
  */
 function trashRequiresAsBoolean (electronVersion, dependencyMap) {
-  const trashDepends = dependencies.getTrashDepends(electronVersion, dependencyMap)
+  const trashDepends = common.getTrashDepends(electronVersion, dependencyMap)
   if (trashDepends.length === 1) {
     return [trashDepends[0]]
   } else {
@@ -57,7 +57,7 @@ module.exports = {
    * The dependencies for Electron itself, given an Electron version.
    */
   forElectron: function dependenciesForElectron (electronVersion, logger) {
-    const requires = dependencies.getDepends(electronVersion, dependencyMap)
+    const requires = common.getDepends(electronVersion, dependencyMap)
     return module.exports.rpmSupportsBooleanDependencies(logger)
       .then(supportsBooleanDependencies => {
         if (supportsBooleanDependencies) {

--- a/src/installer.js
+++ b/src/installer.js
@@ -3,12 +3,9 @@
 const _ = require('lodash')
 const common = require('electron-installer-common')
 const debug = require('debug')
-const dependencies = require('electron-installer-common/src/dependencies')
 const fs = require('fs-extra')
 const nodeify = require('nodeify')
 const path = require('path')
-const readElectronVersion = require('electron-installer-common/src/readelectronversion')
-const replaceScopeName = require('electron-installer-common/src/replacescopename')
 const wrap = require('word-wrap')
 
 const redhatDependencies = require('./dependencies')
@@ -26,7 +23,7 @@ const defaultRename = function (dest, src) {
  * read from `package.json`, and some are hardcoded.
  */
 const getDefaults = function (data) {
-  return readElectronVersion(data.src)
+  return common.readElectronVersion(data.src)
     .then(electronVersion => Promise.all([common.readMeta(data), redhatDependencies.forElectron(electronVersion, data.logger)]))
     .then(([pkg, requires]) => {
       if (!pkg) {
@@ -69,7 +66,7 @@ function getOptions (data, defaults) {
   // Flatten everything for ease of use.
   const options = _.defaults({}, data, data.options, defaults)
 
-  options.name = replaceScopeName(options.name)
+  options.name = common.replaceScopeName(options.name)
 
   if (!options.description && !options.productDescription) {
     throw new Error(`No Description or ProductDescription provided. Please set either a description in the app's package.json or provide it in the options.`)
@@ -85,7 +82,7 @@ function getOptions (data, defaults) {
   options.productDescription = wrap(options.productDescription, { width: 80, indent: '' })
 
   // Merges user and default dependencies
-  options.requires = dependencies.mergeUserSpecified(data, 'requires', defaults)
+  options.requires = common.mergeUserSpecified(data, 'requires', defaults)
 
   // Scan if there are any installation scripts and adds them to the options
   return generateScripts(options)

--- a/src/installer.js
+++ b/src/installer.js
@@ -66,7 +66,7 @@ function getOptions (data, defaults) {
   // Flatten everything for ease of use.
   const options = _.defaults({}, data, data.options, defaults)
 
-  options.name = common.replaceScopeName(options.name)
+  options.name = common.sanitizeName(options.name, '-._+a-zA-Z0-9')
 
   if (!options.description && !options.productDescription) {
     throw new Error(`No Description or ProductDescription provided. Please set either a description in the app's package.json or provide it in the options.`)

--- a/test/installer.js
+++ b/test/installer.js
@@ -118,11 +118,21 @@ describe('module', function () {
   describeInstaller(
     'with an app with a scoped name',
     {
-      src: 'test/fixtures/app-without-asar/',
+      src: 'test/fixtures/app-with-asar/',
       options: { name: '@scoped/myapp' }
     },
-    'generates a .deb package',
-    outputDir => access(path.join(outputDir, 'scoped_myapp.x86_64.rpm'))
+    'generates a .rpm package',
+    outputDir => access(path.join(outputDir, 'scoped-myapp.x86_64.rpm'))
+  )
+
+  describeInstaller(
+    'with an app that needs its name sanitized',
+    {
+      src: 'test/fixtures/app-with-asar/',
+      options: { name: 'Foo/Bar/Baz' }
+    },
+    'generates a .rpm package',
+    outputDir => access(path.join(outputDir, 'Foo-Bar-Baz.x86_64.rpm'))
   )
 
   describeInstaller(


### PR DESCRIPTION
Reference: https://fedoraproject.org/wiki/Packaging:Naming#Common_Character_Set_for_Package_Naming

Addresses electron-userland/electron-forge#654.

Also, cleans up `-common` imports.