### PR TITLE
Revision fix

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -15,7 +15,7 @@ const util = require('./util')
 const defaultLogger = debug('electron-installer-redhat')
 
 const defaultRename = function (dest, src) {
-  return path.join(dest, '<%= name %>-<%= version %>.<%= arch %>.rpm')
+  return path.join(dest, '<%= name %>-<%= version %>-<%= revision %>.<%= arch %>.rpm')
 }
 
 class RedhatInstaller extends common.ElectronInstaller {

--- a/test/cli.js
+++ b/test/cli.js
@@ -29,7 +29,7 @@ describe('cli', function () {
 
     runCLI({ src: 'test/fixtures/app-with-asar/', dest: outputDir, arch: 'x86' })
 
-    it('generates a `.rpm` package', () => access(path.join(outputDir, 'footest-0.0.1.x86.rpm')))
+    it('generates a `.rpm` package', () => access(path.join(outputDir, 'footest-0.0.1-1.x86.rpm')))
 
     cleanupOutputDir(outputDir)
   })
@@ -39,7 +39,7 @@ describe('cli', function () {
 
     runCLI({ src: 'test/fixtures/app-without-asar/', dest: outputDir, arch: 'x86_64' })
 
-    it('generates a `.rpm` package', () => access(path.join(outputDir, 'bartest-0.0.1.x86_64.rpm')))
+    it('generates a `.rpm` package', () => access(path.join(outputDir, 'bartest-0.0.1-1.x86_64.rpm')))
 
     after(() => fs.remove(outputDir))
   })


### PR DESCRIPTION
It seems that the release number is not optional for RPM. As seen in https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/

> The package release number MUST always be present while the others may or may not be depending on the situation.

This is probably a breaking change too.

This also fixes #113 