### PR TITLE
feat: use Node 8 syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
 - '10'
 - '8'
-- '6'
 dist: xenial
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Requirements
 
-This tool requires Node 6 or greater and `rpmbuild` to build the `.rpm` package.
+This tool requires Node 8 or greater and `rpmbuild` to build the `.rpm` package.
 
 **Note**: If your application uses the [Electron API's `shell.moveItemToTrash` method](https://electronjs.org/docs/api/shell#shellmoveitemtotrashfullpath), RPM 4.13.0 or greater is required, due to the [boolean dependency feature](http://rpm.org/user_doc/boolean_dependencies.html).
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ $ npm install --save-dev electron-installer-redhat
 
 Edit the `scripts` section of your `package.json`:
 
-```js
+```json
 {
   "name": "app",
   "description": "An awesome app!",
@@ -147,16 +147,16 @@ You'll end up with the package at `dist/installers/app-0.0.1.x86_64.rpm`.
 
 Install the package locally:
 
-```
+```shell
 $ npm install --save-dev electron-installer-redhat
 ```
 
 And write something like this:
 
-```js
-var installer = require('electron-installer-redhat')
+```javascript
+const installer = require('electron-installer-redhat')
 
-var options = {
+const options = {
   src: 'dist/app-linux-x64/',
   dest: 'dist/installers/',
   arch: 'x86_64'
@@ -164,23 +164,23 @@ var options = {
 
 console.log('Creating package (this may take a while)')
 
-installer(options, function (err) {
-  if (err) {
+installer(options)
+  .then(() => console.log(`Successfully created package at ${options.dest}`))
+  .catch(err => {
     console.error(err, err.stack)
     process.exit(1)
-  }
-
-  console.log('Successfully created package at ' + options.dest)
-})
+  })
 ```
 
 You'll end up with the package at `dist/installers/app-0.0.1.x86_64.rpm`.
+
+_Note: As of 2.0.0, the Node-style callback pattern is no longer available. You can use [`util.callbackify`](https://nodejs.org/api/util.html#util_util_callbackify_original) if this is required for your use case._
 
 ### Options
 
 Even though you can pass most of these options through the command-line interface, it may be easier to create a configuration file:
 
-```js
+```javascript
 {
   "dest": "dist/installers/",
   "icon": "resources/Icon.png",
@@ -192,7 +192,7 @@ Even though you can pass most of these options through the command-line interfac
 
 And pass that instead with the `config` option:
 
-```
+```shell
 $ electron-installer-redhat --src dist/app-linux-x64/ --arch x86_64 --config config.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ And point it to your built app:
 $ electron-installer-redhat --src dist/app-linux-x64/ --dest dist/installers/ --arch x86_64
 ```
 
-You'll end up with the package at `dist/installers/app-0.0.1.x86_64.rpm`.
+You'll end up with the package at `dist/installers/app-0.0.1-1.x86_64.rpm`.
 
 ### Scripts
 
@@ -141,7 +141,7 @@ And run the script:
 $ npm run rpm64
 ```
 
-You'll end up with the package at `dist/installers/app-0.0.1.x86_64.rpm`.
+You'll end up with the package at `dist/installers/app-0.0.1-1.x86_64.rpm`.
 
 ### Programmatically
 
@@ -176,7 +176,7 @@ async function main (options) {
 main(options)
 ```
 
-You'll end up with the package at `dist/installers/app-0.0.1.x86_64.rpm`.
+You'll end up with the package at `dist/installers/app-0.0.1-1.x86_64.rpm`.
 
 _Note: As of 2.0.0, the Node-style callback pattern is no longer available. You can use [`util.callbackify`](https://nodejs.org/api/util.html#util_util_callbackify_original) if this is required for your use case._
 
@@ -259,7 +259,7 @@ Version number of the package, used in the [`Version` field of the `spec` file](
 
 #### options.revision
 Type: `String`
-Default: `package.revision`
+Default: `package.revision || 1`
 
 Revision number of the package, used in the [`Release` field of the `spec` file](https://docs.fedoraproject.org/en-US/quick-docs/creating-rpm-packages/index.html#con_rpm-spec-file-overview).
 

--- a/README.md
+++ b/README.md
@@ -162,14 +162,18 @@ const options = {
   arch: 'x86_64'
 }
 
-console.log('Creating package (this may take a while)')
+async function main (options) {
+  console.log('Creating package (this may take a while)')
 
-installer(options)
-  .then(() => console.log(`Successfully created package at ${options.dest}`))
-  .catch(err => {
+  try {
+    await installer(options)
+    console.log(`Successfully created package at ${options.dest}`)
+  } catch (err) {
     console.error(err, err.stack)
     process.exit(1)
-  })
+  }
+}
+main(options)
 ```
 
 You'll end up with the package at `dist/installers/app-0.0.1.x86_64.rpm`.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "electron-installer-common": "^0.6.2",
+    "electron-installer-common": "^0.6.3",
     "fs-extra": "^8.0.1",
     "lodash": "^4.17.4",
     "nodeify": "^1.0.1",
@@ -46,11 +46,10 @@
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.17.2",
-    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-node": "^9.0.1",
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-standard": "^4.0.0",
     "mocha": "^6.0.0",
-    "mz": "^2.7.0",
     "promise-retry": "^1.1.1",
     "sinon": "^7.3.2",
     "tmp-promise": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "electron-installer-common": "electron-userland/electron-installer-common#drop-node-6",
+    "electron-installer-common": "electron-userland/electron-installer-common",
     "fs-extra": "^8.0.1",
     "lodash": "^4.17.4",
     "word-wrap": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "electron-installer-common": "^0.6.3",
+    "electron-installer-common": "electron-userland/electron-installer-common#drop-node-6",
     "fs-extra": "^8.0.1",
     "lodash": "^4.17.4",
     "word-wrap": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "linux"
   ],
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 8.0.0"
   },
   "main": "src/installer.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -43,16 +43,16 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "eslint": "^5.12.0",
+    "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
-    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-import": "^2.17.2",
     "eslint-plugin-node": "^8.0.1",
-    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-standard": "^4.0.0",
     "mocha": "^6.0.0",
     "mz": "^2.7.0",
     "promise-retry": "^1.1.1",
-    "sinon": "^7.2.2",
-    "tmp-promise": "^1.0.4"
+    "sinon": "^7.3.2",
+    "tmp-promise": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
     "chai": "^4.1.2",
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
-    "eslint-plugin-import": "^2.17.2",
-    "eslint-plugin-node": "^9.0.1",
+    "eslint-plugin-import": "^2.17.3",
+    "eslint-plugin-node": "^9.1.0",
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-standard": "^4.0.0",
     "mocha": "^6.0.0",
     "promise-retry": "^1.1.1",
     "sinon": "^7.3.2",
-    "tmp-promise": "^1.1.0"
+    "tmp-promise": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "electron-installer-common": "^0.6.3",
     "fs-extra": "^8.0.1",
     "lodash": "^4.17.4",
-    "nodeify": "^1.0.1",
     "word-wrap": "^1.2.3",
     "yargs": "^13.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "electron-installer-common": "electron-userland/electron-installer-common",
+    "electron-installer-common": "^0.7.0",
     "fs-extra": "^8.0.1",
     "lodash": "^4.17.4",
     "word-wrap": "^1.2.3",

--- a/src/installer.js
+++ b/src/installer.js
@@ -61,7 +61,7 @@ class RedhatInstaller extends common.ElectronInstaller {
     const dest = path.join(process.env.HOME, '.rpmmacros')
     this.options.logger(`Creating macros file at ${dest}`)
 
-    return common.wrapError('creating macros file', async () => common.createTemplatedFile(src, dest, Object.assign({ dir: this.stagingDir }, this.options)))
+    return common.wrapError('creating macros file', async () => common.createTemplatedFile(src, dest, { dir: this.stagingDir, ...this.options }))
   }
 
   /**
@@ -96,17 +96,18 @@ class RedhatInstaller extends common.ElectronInstaller {
       (async () => (await common.readMetadata(this.userSupplied)) || {})(),
       redhatDependencies.forElectron(electronVersion, this.userSupplied.logger)
     ])
-    this.defaults = Object.assign(common.getDefaultsFromPackageJSON(pkg), {
+    this.defaults = {
+      ...common.getDefaultsFromPackageJSON(pkg),
       version: pkg.version || '0.0.0',
       license: pkg.license,
       compressionLevel: 2,
       icon: path.resolve(__dirname, '../resources/icon.png'),
-
       pre: undefined,
       post: undefined,
       preun: undefined,
-      postun: undefined
-    }, requires)
+      postun: undefined,
+      ...requires
+    }
 
     return this.defaults
   }

--- a/src/installer.js
+++ b/src/installer.js
@@ -97,7 +97,7 @@ class RedhatInstaller extends common.ElectronInstaller {
       redhatDependencies.forElectron(electronVersion, this.userSupplied.logger)
     ])
     this.defaults = {
-      ...common.getDefaultsFromPackageJSON(pkg),
+      ...common.getDefaultsFromPackageJSON(pkg, { revision: 1 }),
       version: pkg.version || '0.0.0',
       license: pkg.license,
       compressionLevel: 2,

--- a/src/installer.js
+++ b/src/installer.js
@@ -4,7 +4,6 @@ const _ = require('lodash')
 const common = require('electron-installer-common')
 const debug = require('debug')
 const fs = require('fs-extra')
-const nodeify = require('nodeify')
 const path = require('path')
 const wrap = require('word-wrap')
 
@@ -171,18 +170,13 @@ class RedhatInstaller extends common.ElectronInstaller {
 
 /* ************************************************************************** */
 
-module.exports = (data, callback) => {
+module.exports = data => {
   data.rename = data.rename || defaultRename
   data.logger = data.logger || defaultLogger
 
-  if (callback) {
-    console.warn('The node-style callback is deprecated. In a future major version, it will be' +
-                 'removed in favor of a Promise-based async style.')
-  }
-
   const installer = new RedhatInstaller(data)
 
-  const promise = installer.generateDefaults()
+  return installer.generateDefaults()
     .then(() => installer.generateOptions())
     .then(() => installer.generateScripts())
     .then(() => data.logger(`Creating package with options\n${JSON.stringify(installer.options, null, 2)}`))
@@ -198,8 +192,6 @@ module.exports = (data, callback) => {
       data.logger(common.errorMessage('creating package', err))
       throw err
     })
-
-  return nodeify(promise, callback)
 }
 
 module.exports.Installer = RedhatInstaller

--- a/src/installer.js
+++ b/src/installer.js
@@ -48,9 +48,9 @@ class RedhatInstaller extends common.ElectronInstaller {
   /**
    * Copy the application into the package.
    */
-  copyApplication () {
-    return super.copyApplication()
-      .then(() => this.updateSandboxHelperPermissions())
+  async copyApplication () {
+    await super.copyApplication()
+    return this.updateSandboxHelperPermissions()
   }
 
   /**
@@ -61,18 +61,17 @@ class RedhatInstaller extends common.ElectronInstaller {
     const dest = path.join(process.env.HOME, '.rpmmacros')
     this.options.logger(`Creating macros file at ${dest}`)
 
-    return common.createTemplatedFile(src, dest, Object.assign({ dir: this.stagingDir }, this.options))
-      .catch(common.wrapError('creating macros file'))
+    return common.wrapError('creating macros file', async () => common.createTemplatedFile(src, dest, Object.assign({ dir: this.stagingDir }, this.options)))
   }
 
   /**
    * Package everything using `rpmbuild`.
    */
-  createPackage () {
+  async createPackage () {
     this.options.logger(`Creating package at ${this.stagingDir}`)
 
-    return spawn('rpmbuild', ['-bb', this.specPath, '--target', this.options.arch], this.options.logger)
-      .then(output => this.options.logger(`rpmbuild output: ${output}`))
+    const output = await spawn('rpmbuild', ['-bb', this.specPath, '--target', this.options.arch], this.options.logger)
+    this.options.logger(`rpmbuild output: ${output}`)
   }
 
   /**
@@ -80,40 +79,36 @@ class RedhatInstaller extends common.ElectronInstaller {
    *
    * See: https://fedoraproject.org/wiki/How_to_create_an_RPM_package
    */
-  createSpec () {
+  async createSpec () {
     const src = path.resolve(__dirname, '../resources/spec.ejs')
     this.options.logger(`Creating spec file at ${this.specPath}`)
 
-    return this.createTemplatedFile(src, this.specPath)
-      .catch(common.wrapError('creating spec file'))
+    return common.wrapError('creating spec file', async () => this.createTemplatedFile(src, this.specPath))
   }
 
   /**
    * Get the hash of default options for the installer. Some come from the info
    * read from `package.json`, and some are hardcoded.
    */
-  generateDefaults () {
-    return common.readElectronVersion(this.userSupplied.src)
-      .then(electronVersion => Promise.all([
-        common.readMetadata(this.userSupplied),
-        redhatDependencies.forElectron(electronVersion, this.userSupplied.logger)
-      ])).then(([pkg, requires]) => {
-        pkg = pkg || {}
+  async generateDefaults () {
+    const electronVersion = await common.readElectronVersion(this.userSupplied.src)
+    const [pkg, requires] = await Promise.all([
+      (async () => (await common.readMetadata(this.userSupplied)) || {})(),
+      redhatDependencies.forElectron(electronVersion, this.userSupplied.logger)
+    ])
+    this.defaults = Object.assign(common.getDefaultsFromPackageJSON(pkg), {
+      version: pkg.version || '0.0.0',
+      license: pkg.license,
+      compressionLevel: 2,
+      icon: path.resolve(__dirname, '../resources/icon.png'),
 
-        this.defaults = Object.assign(common.getDefaultsFromPackageJSON(pkg), {
-          version: pkg.version || '0.0.0',
-          license: pkg.license,
-          compressionLevel: 2,
-          icon: path.resolve(__dirname, '../resources/icon.png'),
+      pre: undefined,
+      post: undefined,
+      preun: undefined,
+      postun: undefined
+    }, requires)
 
-          pre: undefined,
-          post: undefined,
-          preun: undefined,
-          postun: undefined
-        }, requires)
-
-        return this.defaults
-      })
+    return this.defaults
   }
 
   /**
@@ -146,14 +141,13 @@ class RedhatInstaller extends common.ElectronInstaller {
   /**
    * Read scripts from provided filename and add them to the options
    */
-  generateScripts () {
+  async generateScripts () {
     const scriptNames = ['pre', 'post', 'preun', 'postun']
 
-    return Promise.all(_.map(this.options.scripts, (item, key) => {
+    return Promise.all(_.map(this.options.scripts, async (item, key) => {
       if (scriptNames.includes(key)) {
         this.options.logger(`Creating installation script ${key}`)
-        return fs.readFile(item)
-          .then(script => (this.options[key] = script.toString()))
+        this.options[key] = (await fs.readFile(item)).toString()
       }
     }))
   }
@@ -170,28 +164,23 @@ class RedhatInstaller extends common.ElectronInstaller {
 
 /* ************************************************************************** */
 
-module.exports = data => {
+module.exports = async data => {
   data.rename = data.rename || defaultRename
   data.logger = data.logger || defaultLogger
 
   const installer = new RedhatInstaller(data)
 
-  return installer.generateDefaults()
-    .then(() => installer.generateOptions())
-    .then(() => installer.generateScripts())
-    .then(() => data.logger(`Creating package with options\n${JSON.stringify(installer.options, null, 2)}`))
-    .then(() => installer.createStagingDir())
-    .then(() => installer.createMacros())
-    .then(() => installer.createContents())
-    .then(() => installer.createPackage())
-    .then(() => installer.movePackage())
-    .then(() => {
-      data.logger(`Successfully created package at ${installer.options.dest}`)
-      return installer.options
-    }).catch(err => {
-      data.logger(common.errorMessage('creating package', err))
-      throw err
-    })
+  await installer.generateDefaults()
+  await installer.generateOptions()
+  await installer.generateScripts()
+  await data.logger(`Creating package with options\n${JSON.stringify(installer.options, null, 2)}`)
+  await installer.createStagingDir()
+  await installer.createMacros()
+  await installer.createContents()
+  await installer.createPackage()
+  await installer.movePackage()
+  data.logger(`Successfully created package at ${installer.options.dest}`)
+  return installer.options
 }
 
 module.exports.Installer = RedhatInstaller

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -12,20 +12,16 @@ describe('dependencies', () => {
       sinon.restore()
     })
 
-    it('uses an RPM that does not support boolean dependencies', () => {
+    it('uses an RPM that does not support boolean dependencies', async () => {
       sinon.stub(dependencies, 'rpmSupportsBooleanDependencies').resolves(false)
-      return dependencies.forElectron('v1.0.0')
-        .then(result => {
-          expect(console.warn.calledWithMatch(/^You are using RPM < 4.13/)).to.equal(true)
-        })
+      await dependencies.forElectron('v1.0.0')
+      expect(console.warn.calledWithMatch(/^You are using RPM < 4.13/)).to.equal(true)
     })
 
-    it('uses an RPM that supports boolean dependencies', () => {
+    it('uses an RPM that supports boolean dependencies', async () => {
       sinon.stub(dependencies, 'rpmSupportsBooleanDependencies').resolves(true)
-      return dependencies.forElectron('v1.0.0')
-        .then(result => {
-          expect(console.warn.calledWithMatch(/^You are using RPM < 4.13/)).to.equal(false)
-        })
+      await dependencies.forElectron('v1.0.0')
+      expect(console.warn.calledWithMatch(/^You are using RPM < 4.13/)).to.equal(false)
     })
   })
 

--- a/test/helpers/describe_installer.js
+++ b/test/helpers/describe_installer.js
@@ -8,34 +8,36 @@ const tmp = require('tmp-promise')
 
 const installer = require('../..')
 
-module.exports = function describeInstaller (description, installerOptions, itDescription, itFunc) {
-  describe(description, test => {
-    const outputDir = module.exports.tempOutputDir(installerOptions.dest)
-    const options = module.exports.testInstallerOptions(outputDir, installerOptions)
+module.exports = {
+  describeInstaller: function describeInstaller (description, installerOptions, itDescription, itFunc) {
+    describe(description, test => {
+      const outputDir = module.exports.tempOutputDir(installerOptions.dest)
+      const options = module.exports.testInstallerOptions(outputDir, installerOptions)
 
-    before(() => installer(options))
+      before(async () => installer(options))
 
-    it(itDescription, () => itFunc(outputDir))
+      it(itDescription, () => itFunc(outputDir))
 
-    module.exports.cleanupOutputDir(outputDir)
-  })
-}
+      module.exports.cleanupOutputDir(outputDir)
+    })
+  },
 
-module.exports.cleanupOutputDir = function cleanupOutputDir (outputDir) {
-  after(() => fs.remove(outputDir))
-}
+  cleanupOutputDir: function cleanupOutputDir (outputDir) {
+    after(async () => fs.remove(outputDir))
+  },
 
-module.exports.tempOutputDir = function tempOutputDir (customDir) {
-  return customDir ? path.join(os.tmpdir(), customDir) : tmp.tmpNameSync({ prefix: 'electron-installer-redhat-' })
-}
+  tempOutputDir: function tempOutputDir (customDir) {
+    return customDir ? path.join(os.tmpdir(), customDir) : tmp.tmpNameSync({ prefix: 'electron-installer-redhat-' })
+  },
 
-module.exports.testInstallerOptions = function testInstallerOptions (outputDir, installerOptions) {
-  return _.merge({
-    rename: rpmFile => {
-      return path.join(rpmFile, '<%= name %>.<%= arch %>.rpm')
-    },
-    options: {
-      arch: 'x86_64'
-    }
-  }, installerOptions, { dest: outputDir })
+  testInstallerOptions: function testInstallerOptions (outputDir, installerOptions) {
+    return _.merge({
+      rename: rpmFile => {
+        return path.join(rpmFile, '<%= name %>.<%= arch %>.rpm')
+      },
+      options: {
+        arch: 'x86_64'
+      }
+    }, installerOptions, { dest: outputDir })
+  }
 }

--- a/test/installer.js
+++ b/test/installer.js
@@ -1,15 +1,14 @@
 'use strict'
 
-const fs = require('fs-extra')
-const path = require('path')
-
-const installer = require('..')
-
-const { exec } = require('mz/child_process')
 const access = require('./helpers/access')
-const describeInstaller = require('./helpers/describe_installer')
-const tempOutputDir = describeInstaller.tempOutputDir
-const testInstallerOptions = describeInstaller.testInstallerOptions
+const childProcess = require('child_process')
+const describeInstaller, { tempOutputDir, testInstallerOptions } = require('./helpers/describe_installer')
+const fs = require('fs-extra')
+const installer = require('..')
+const path = require('path')
+const { promisify } = require('util')
+
+const exec = promisify(childProcess.exec)
 
 const assertASARRpmExists = outputDir =>
   access(path.join(outputDir, 'footest.x86.rpm'))

--- a/test/installer.js
+++ b/test/installer.js
@@ -2,7 +2,7 @@
 
 const access = require('./helpers/access')
 const childProcess = require('child_process')
-const describeInstaller, { tempOutputDir, testInstallerOptions } = require('./helpers/describe_installer')
+const { describeInstaller, tempOutputDir, testInstallerOptions } = require('./helpers/describe_installer')
 const fs = require('fs-extra')
 const installer = require('..')
 const path = require('path')
@@ -15,6 +15,12 @@ const assertASARRpmExists = outputDir =>
 
 const assertNonASARRpmExists = outputDir =>
   access(path.join(outputDir, 'bartest.x86_64.rpm'))
+
+const updateJSON = async (filename, updateFunc) => {
+  const packageJSON = await fs.readJson(filename)
+  updateFunc(packageJSON)
+  await fs.writeJson(filename, packageJSON)
+}
 
 describe('module', function () {
   this.timeout(10000)
@@ -56,28 +62,17 @@ describe('module', function () {
     const baseDir = tempOutputDir('app-without-homepage')
     let outputDir
 
-    after(() => fs.remove(baseDir))
-    after(() => fs.remove(outputDir))
+    after(async () => fs.remove(baseDir))
+    after(async () => fs.remove(outputDir))
 
-    before(() => {
-      let pkgJSONFilename
-      return fs.emptyDir(baseDir)
-        .then(() => fs.copy('test/fixtures/app-without-asar', baseDir))
-        .then(() => {
-          pkgJSONFilename = path.join(baseDir, 'resources', 'app', 'package.json')
-          return pkgJSONFilename
-        })
-        .then(file => fs.readJson(file))
-        .then(pkgJSON => {
-          pkgJSON.author = 'Test Author'
-          return fs.writeJson(pkgJSONFilename, pkgJSON)
-        })
-        .then(() => tempOutputDir())
-        .then(tmpdir => {
-          outputDir = tmpdir
-          return testInstallerOptions(outputDir, { src: baseDir })
-        })
-        .then(options => installer(options))
+    before(async () => {
+      await fs.emptyDir(baseDir)
+      await fs.copy('test/fixtures/app-without-asar', baseDir)
+      await updateJSON(path.join(baseDir, 'resources', 'app', 'package.json'), packageJSON => {
+        packageJSON.author = 'Test Author'
+      })
+      outputDir = tempOutputDir()
+      await installer(testInstallerOptions(outputDir, { src: baseDir }))
     })
 
     it('generates a `.rpm` package', () => assertNonASARRpmExists(outputDir))
@@ -87,28 +82,17 @@ describe('module', function () {
     const baseDir = tempOutputDir('app-with-hyphen')
     let outputDir
 
-    after(() => fs.remove(baseDir))
-    after(() => fs.remove(outputDir))
+    after(async () => fs.remove(baseDir))
+    after(async () => fs.remove(outputDir))
 
-    before(() => {
-      let pkgJSONFilename
-      return fs.emptyDir(baseDir)
-        .then(() => fs.copy('test/fixtures/app-without-asar', baseDir))
-        .then(() => {
-          pkgJSONFilename = path.join(baseDir, 'resources', 'app', 'package.json')
-          return pkgJSONFilename
-        })
-        .then(file => fs.readJson(file))
-        .then(pkgJSON => {
-          pkgJSON.version = '1.0.0-beta+internal-only.0'
-          return fs.writeJson(pkgJSONFilename, pkgJSON)
-        })
-        .then(() => tempOutputDir())
-        .then(tmpdir => {
-          outputDir = tmpdir
-          return testInstallerOptions(outputDir, { src: baseDir })
-        })
-        .then(options => installer(options))
+    before(async () => {
+      await fs.emptyDir(baseDir)
+      await fs.copy('test/fixtures/app-without-asar', baseDir)
+      await updateJSON(path.join(baseDir, 'resources', 'app', 'package.json'), packageJSON => {
+        packageJSON.version = '1.0.0-beta+internal-only.0'
+      })
+      outputDir = tempOutputDir()
+      await installer(testInstallerOptions(outputDir, { src: baseDir }))
     })
 
     it('generates a `.rpm` package', () => assertNonASARRpmExists(outputDir))
@@ -138,15 +122,14 @@ describe('module', function () {
       }
     },
     'generates a `.rpm` package with scripts',
-    outputDir => assertNonASARRpmExists(outputDir)
-      .then(() => exec('rpm -qp --scripts bartest.x86_64.rpm', { cwd: outputDir }))
-      .then(stdout => {
-        stdout = stdout.toString()
-        const scripts = ['preinstall', 'postinstall', 'preuninstall', 'postuninstall']
-        if (!scripts.every(element => stdout.includes(element))) {
-          throw new Error(`Some installation scripts are missing:\n ${stdout}`)
-        }
-        return Promise.resolve
-      })
+    async outputDir => {
+      await assertNonASARRpmExists(outputDir)
+      let { stdout } = await exec('rpm -qp --scripts bartest.x86_64.rpm', { cwd: outputDir })
+      stdout = stdout.toString()
+      const scripts = ['preinstall', 'postinstall', 'preuninstall', 'postuninstall']
+      if (!scripts.every(element => stdout.includes(element))) {
+        throw new Error(`Some installation scripts are missing:\n ${stdout}`)
+      }
+    }
   )
 })


### PR DESCRIPTION
BREAKING CHANGE: drop support for Node < 8.

Requires https://github.com/electron-userland/electron-installer-common/pull/27 to be merged/deployed.