### PR TITLE
fix: add openSUSE package name variant for kde-cli-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "electron-installer-common": "electron-userland/electron-installer-common#multiple-trash-dep-options",
+    "electron-installer-common": "^0.7.3",
     "fs-extra": "^8.0.1",
     "lodash": "^4.17.4",
     "word-wrap": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "electron-installer-common": "^0.7.1",
+    "electron-installer-common": "electron-userland/electron-installer-common#multiple-trash-dep-options",
     "fs-extra": "^8.0.1",
     "lodash": "^4.17.4",
     "word-wrap": "^1.2.3",

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -10,7 +10,7 @@ const dependencyMap = {
   gtk2: 'gtk2',
   gtk3: 'gtk3',
   gvfs: 'gvfs-client',
-  kdeCliTools: 'kde-cli-tools',
+  kdeCliTools: ['kde-cli-tools', 'kde-cli-tools5'],
   kdeRuntime: 'kde-runtime',
   notify: 'libnotify',
   nss: 'nss',


### PR DESCRIPTION
Fixes #130.

## TODO

* [x] Merge https://github.com/electron-userland/electron-installer-common/pull/37
* [x] Release a new version of `electron-installer-common`
* [x] Update `package.json` accordingly