### PR TITLE
Add dependency alternatives for OpenSuse Leap 15.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - '12'
 - '8'
-dist: xenial
+dist: bionic
 cache:
   directories:
   - node_modules

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -12,13 +12,13 @@ const dependencyMap = {
   gvfs: 'gvfs-client',
   kdeCliTools: ['kde-cli-tools', 'kde-cli-tools5'],
   kdeRuntime: 'kde-runtime',
-  notify: 'libnotify or libnotify4',
-  nss: 'nss or mozilla-nss',
+  notify: '(libnotify or libnotify4)',
+  nss: '(nss or mozilla-nss)',
   trashCli: 'trash-cli',
-  uuid: 'libuuid or libuuid1',
+  uuid: '(libuuid or libuuid1)',
   xdgUtils: 'xdg-utils',
   xss: 'libXScrnSaver',
-  xtst: 'libXtst or libXtst6'
+  xtst: '(libXtst or libXtst6)'
 }
 
 /**

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -12,13 +12,13 @@ const dependencyMap = {
   gvfs: 'gvfs-client',
   kdeCliTools: ['kde-cli-tools', 'kde-cli-tools5'],
   kdeRuntime: 'kde-runtime',
-  notify: 'libnotify',
-  nss: 'nss',
+  notify: ['libnotify', 'libnotify4'],
+  nss: ['nss', 'mozilla-nss'],
   trashCli: 'trash-cli',
-  uuid: 'libuuid',
+  uuid: ['libuuid', 'libuuid1'],
   xdgUtils: 'xdg-utils',
   xss: 'libXScrnSaver',
-  xtst: 'libXtst'
+  xtst: ['libXtst', 'libXtst6']
 }
 
 /**

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -12,13 +12,13 @@ const dependencyMap = {
   gvfs: 'gvfs-client',
   kdeCliTools: ['kde-cli-tools', 'kde-cli-tools5'],
   kdeRuntime: 'kde-runtime',
-  notify: ['libnotify', 'libnotify4'],
-  nss: ['nss', 'mozilla-nss'],
+  notify: 'libnotify or libnotify4',
+  nss: 'nss or mozilla-nss',
   trashCli: 'trash-cli',
-  uuid: ['libuuid', 'libuuid1'],
+  uuid: 'libuuid or libuuid1',
   xdgUtils: 'xdg-utils',
   xss: 'libXScrnSaver',
-  xtst: ['libXtst', 'libXtst6']
+  xtst: 'libXtst or libXtst6'
 }
 
 /**


### PR DESCRIPTION
This pull request addresses #130. There is a pre-condition that changes in electron-installer-common (see [this pull request](https://github.com/electron-userland/electron-installer-common/pull/40)) are first merged and released on npmjs, before this change can work.