### PR TITLE
fix: handle parsing versions from RPM >= 4.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "mocha": "^7.0.0",
     "promise-retry": "^1.1.1",
+    "proxyquire": "^2.1.3",
     "sinon": "^9.0.0",
     "tmp-promise": "^3.0.2"
   }

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -22,21 +22,17 @@ const dependencyMap = {
   xtst: '(libXtst or libXtst6)'
 }
 
-async function getRpmVersion (logger, spawnProgram = spawn) {
-  const versionOutput = await spawnProgram('rpmbuild', ['--version'], logger)
-
-  const parts = versionOutput.trim().split(' ')
-  const versionNumber = _.last(parts)
-
-  return versionNumber
-}
 /**
  * Retrieves the RPM version number and determines whether it has support for boolean
  * dependencies (>= 4.13.0).
  */
 async function rpmSupportsBooleanDependencies (logger) {
-  const versionNumber = await getRpmVersion(logger)
-  return module.exports.rpmVersionSupportsBooleanDependencies(versionNumber)
+  return rpmVersionSupportsBooleanDependencies(await getRpmVersion(logger))
+}
+
+async function getRpmVersion (logger) {
+  const versionOutput = await spawn('rpmbuild', ['--version'], logger)
+  return _.last(versionOutput.trim().split(' '))
 }
 
 /**

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -1,7 +1,8 @@
+const chaiAsPromised = require('chai-as-promised')
 const dependencies = require('../src/dependencies')
 const { expect, use } = require('chai')
+const proxyquire = require('proxyquire').noPreserveCache()
 const sinon = require('sinon')
-const chaiAsPromised = require('chai-as-promised')
 
 use(chaiAsPromised)
 
@@ -13,35 +14,32 @@ describe('dependencies', () => {
 
     it('uses an RPM that does not support boolean dependencies', async () => {
       sinon.stub(dependencies, 'rpmSupportsBooleanDependencies').resolves(false)
-      expect(dependencies.forElectron('v1.0.0')).to.eventually.be.rejectedWith(/^Please upgrade to RPM 4\.13/)
+      await expect(dependencies.forElectron('v1.0.0')).to.eventually.be.rejectedWith(/^Please upgrade to RPM 4\.13/)
     })
 
     it('uses an RPM that supports boolean dependencies', async () => {
       sinon.stub(dependencies, 'rpmSupportsBooleanDependencies').resolves(true)
-      expect(dependencies.forElectron('v1.0.0')).to.be.fulfilled // eslint-disable-line no-unused-expressions
+      await expect(dependencies.forElectron('v1.0.0')).to.be.fulfilled // eslint-disable-line no-unused-expressions
     })
   })
 
   describe('getRpmVersion', () => {
-    afterEach(() => {
-      sinon.restore()
-    })
+    function stubGetRpmVersion (versionOutput) {
+      const { getRpmVersion } = proxyquire('../src/dependencies', {
+        './spawn': async () => Promise.resolve(versionOutput)
+      })
+
+      return getRpmVersion
+    }
+
     it('parses version output from RPM < 4.15', async () => {
-      const versionOutput = 'RPM version 4.14.2.1\n'
-      const spawnProgram = sinon.stub().resolves(versionOutput)
-
-      const actualOutput = await dependencies.getRpmVersion(null, spawnProgram)
-
-      expect(actualOutput).to.equal('4.14.2.1')
+      const getRpmVersion = stubGetRpmVersion('RPM version 4.14.2.1\n')
+      await expect(getRpmVersion(null)).to.eventually.equal('4.14.2.1')
     })
 
     it('parses version output from RPM >= 4.15', async () => {
-      const versionOutput = 'RPM-Version 4.15.1\n'
-      const spawnProgram = sinon.stub().resolves(versionOutput)
-
-      const actualOutput = await dependencies.getRpmVersion(null, spawnProgram)
-
-      expect(actualOutput).to.equal('4.15.1')
+      const getRpmVersion = stubGetRpmVersion('RPM-Version 4.15.1\n')
+      await expect(getRpmVersion(null)).to.eventually.equal('4.15.1')
     })
   })
 

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -22,6 +22,29 @@ describe('dependencies', () => {
     })
   })
 
+  describe('getRpmVersion', () => {
+    afterEach(() => {
+      sinon.restore()
+    })
+    it('parses version output from RPM < 4.15', async () => {
+      const versionOutput = 'RPM version 4.14.2.1\n'
+      const spawnProgram = sinon.stub().resolves(versionOutput)
+
+      const actualOutput = await dependencies.getRpmVersion(null, spawnProgram)
+
+      expect(actualOutput).to.equal('4.14.2.1')
+    })
+
+    it('parses version output from RPM >= 4.15', async () => {
+      const versionOutput = 'RPM-Version 4.15.1\n'
+      const spawnProgram = sinon.stub().resolves(versionOutput)
+
+      const actualOutput = await dependencies.getRpmVersion(null, spawnProgram)
+
+      expect(actualOutput).to.equal('4.15.1')
+    })
+  })
+
   describe('rpmVersionSupportsBooleanDependencies', () => {
     it('works with release candidates', () => {
       expect(dependencies.rpmVersionSupportsBooleanDependencies('4.13.0-rc1')).to.equal(true)


### PR DESCRIPTION
"npm run make" crashes when the rpmbuild version is `[ 'RPM-Version', '4.15.1' ]`. With this fix, we always take the last part of the version string, which should be the version number.

On my system, the output of `rpmbuild --version` only contains a single string: `RPM-Version 4.15.1`. In this case, making the project crashes with the error message `Cannot read property 'split' of undefined`.

This change always takes the last part of the version string to compare the version number instead of using the hard-coded value `2` as an index - which might not exist.

I am running on:

```
NAME=Fedora
VERSION="32 (Workstation Edition)"
ID=fedora
VERSION_ID=32
VERSION_CODENAME=""
PLATFORM_ID="platform:f32"
PRETTY_NAME="Fedora 32 (Workstation Edition)"
```

Fixes #163.