### PR TITLE
chore: fix any fixable lint warnings before committing changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,18 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
+    "husky": "^4.2.5",
+    "lint-staged": "^10.2.7",
     "mocha": "^7.0.0",
     "promise-retry": "^1.1.1",
     "proxyquire": "^2.1.3",
     "sinon": "^9.0.0",
     "tmp-promise": "^3.0.2"
+  },
+  "husky": {
+    "pre-commit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.js": "eslint --fix"
   }
 }


### PR DESCRIPTION
I keep forgetting to run ESLint before making commits. This makes it automatic.