### PR TITLE
fix: Define array options to yargs

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -25,6 +25,9 @@ const argv = yargs
     describe: 'JSON file that contains the metadata for your application',
     config: true
   })
+  .options('options.execArguments', { array: true, hidden: true })
+  .options('options.categories', { array: true, hidden: true })
+  .options('options.mimeType', { array: true, hidden: true })
   .example('$0 --src dist/app/ --dest dist/installer/ --arch i386', 'use metadata from `dist/app/`')
   .example('$0 --src dist/app/ --dest dist/installer/ --config config.json', 'use metadata from `config.json`')
   .wrap(null)

--- a/src/cli.js
+++ b/src/cli.js
@@ -25,6 +25,7 @@ const argv = yargs
     describe: 'JSON file that contains the metadata for your application',
     config: true
   })
+  .options('options.requires', { array: true, hidden: true })
   .options('options.execArguments', { array: true, hidden: true })
   .options('options.categories', { array: true, hidden: true })
   .options('options.mimeType', { array: true, hidden: true })


### PR DESCRIPTION
It allows you to pass array options via CLI arguments.