### PR TITLE
feat: add symbolic icon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Or multiple images with their corresponding resolutions:
   }
 }
 ```
-Note that the image files must be one of the types: PNG or SVG. The support for SVG works only on `scalable` or `symbolic` resolutions.
+Per the [icon theme specification](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-0.11.html), image files must either PNGs or SVGs. The SVG format can only be used for the `scalable` or `symbolic` resolutions.
 
 
 #### options.categories

--- a/README.md
+++ b/README.md
@@ -352,10 +352,14 @@ Or multiple images with their corresponding resolutions:
     '48x48': 'resources/Icon48.png',
     '64x64': 'resources/Icon64.png',
     '128x128': 'resources/Icon128.png',
-    '256x256': 'resources/Icon256.png'
+    '256x256': 'resources/Icon256.png',
+    'scalable': 'resources/Icon.svg',
+    'symbolic': 'resources/Icon-symbolic.svg',
   }
 }
 ```
+Note that the image files must be one of the types: PNG or SVG. The support for SVG works only on `scalable` or `symbolic` resolutions.
+
 
 #### options.categories
 Type: `Array[String]`

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -22,7 +22,9 @@ mkdir -p %{buildroot}/usr/
 /usr/lib/<%= name %>/
 /usr/share/applications/<%= name %>.desktop
 /usr/share/doc/<%= name %>/
-<% if (_.isObject(icon)) { %><% _.forEach(icon, function (path, resolution) { %>/usr/share/icons/hicolor/<%= resolution %>/apps/<%= name %>.<%= resolution === 'scalable' ? 'svg' : 'png' %>
+<% if (_.isObject(icon)) { %>
+  <% _.forEach(icon, function (path, resolution) { %>
+/usr/share/icons/hicolor/<%= resolution %>/apps/<%= name %><%= resolution === 'symbolic' ? '-symbolic' : '' %>.<%= ['scalable', 'symbolic'].includes(resolution) ? 'svg' : 'png' %>
 <% }) } else { %>/usr/share/pixmaps/<%= name %>.png
 <% } %>
 

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -22,10 +22,11 @@ mkdir -p %{buildroot}/usr/
 /usr/lib/<%= name %>/
 /usr/share/applications/<%= name %>.desktop
 /usr/share/doc/<%= name %>/
-<% if (_.isObject(icon)) { %>
-  <% _.forEach(icon, function (path, resolution) { %>
-/usr/share/icons/hicolor/<%= resolution %>/apps/<%= name %><%= resolution === 'symbolic' ? '-symbolic' : '' %>.<%= ['scalable', 'symbolic'].includes(resolution) ? 'svg' : 'png' %>
-<% }) } else { %>/usr/share/pixmaps/<%= name %>.png
+<% if (_.isObject(icon)) {
+  _.forEach(icon, function (path, resolution) {
+    %>/usr/share/icons/hicolor/<%= resolution %>/apps/<%= name %><%= resolution === 'symbolic' ? '-symbolic' : '' %>.<%= ['scalable', 'symbolic'].includes(resolution) ? 'svg' : 'png' %>
+<% }) } else {
+  %>/usr/share/pixmaps/<%= name %>.png
 <% } %>
 
 <% if (pre) { %>

--- a/test/installer.js
+++ b/test/installer.js
@@ -112,7 +112,8 @@ describe('module', function () {
       options: {
         arch: 'x86',
         icon: {
-          scalable: 'test/fixtures/scaled-icon.svg'
+          scalable: 'test/fixtures/scaled-icon.svg',
+          symbolic: 'test/fixtures/scaled-icon.svg'
         }
       }
     },


### PR DESCRIPTION
The latest version of `-common` introduced support for symbolic icons but this module needs additional configuration in order for it to work.
`-debian` doesn't require any additional configuration because icons are just copied and there's no need for a specs file.