### PR TITLE
fix: make .ejs more readable

### DIFF
--- a/resources/desktop.ejs
+++ b/resources/desktop.ejs
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=<%= productName %>
-<% if (description) { %>Comment=<%= description %><% } %>
-GenericName=<%= genericName %>
+<% if (description) { print(`Comment=${description}\n`) }
+%>GenericName=<%= genericName %>
 Exec=<%= name %> %U<% if (execArguments && execArguments.length) { %> <%= execArguments.join(' ') %><% } %>
 Icon=<%= name %>
 Type=Application

--- a/resources/desktop.ejs
+++ b/resources/desktop.ejs
@@ -1,11 +1,10 @@
 [Desktop Entry]
-<% if (productName) { %>Name=<%= productName %>
-<% } %><% if (description) { %>Comment=<%= description %>
-<% } %><% if (genericName) { %>GenericName=<%= genericName %>
-<% } %><% if (name) { %>Exec=<%= name %> %U<% if (execArguments && execArguments.length) { %> <%= execArguments.join(' ') %><% } %>
-<% } %><% if (name) { %>Icon=<%= name %>
-<% } %>Type=Application
+Name=<%= productName %>
+<% if (description) { %>Comment=<%= description %><% } %>
+GenericName=<%= genericName %>
+Exec=<%= name %> %U<% if (execArguments && execArguments.length) { %> <%= execArguments.join(' ') %><% } %>
+Icon=<%= name %>
+Type=Application
 StartupNotify=true
-<% if (categories && categories.length) { %>Categories=<%= categories.join(';') %>;
-<% } %><% if (mimeType && mimeType.length) { %>MimeType=<%= mimeType.join(';') %>;
-<% } %>
+Categories=<%= categories.join(';') %>;
+<% if (mimeType.length) { %>MimeType=<%= mimeType.join(';') %>;<% } %>

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -12,7 +12,6 @@ if (license || homepage) { print('\n') }
 %>Requires: <%= requires.join(', ') %>
 AutoReqProv: no
 
-
 <% if (productDescription) {
 %>%description
 <% print(productDescription)

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -1,21 +1,26 @@
-<% if (name) { %>Name: <%= name %>
-<% } %><% if (version) { %>Version: <%= version %>
-<% } %><% if (revision) { %>Release: <%= revision %>%{?dist}
-<% } %><% if (description) { %>Summary: <%= description %>
-<% } %><% if (homepage) { %>URL: <%= homepage %>
-<% } %><% if (license) { %>License: <%= license %>
-<% } %>
-AutoReqProv: no
-<% if (requires) { %>Requires: <%= requires.join(', ') %>
-<% } %><% if (productDescription) { %>
-%description
-<%= productDescription %>
-<% } %>
 %define _binary_payload w<%= compressionLevel %>.xzdio
+
+Name: <%= name %>
+Version: <%= version %>
+Release: <%= revision %>%{?dist}
+<% if (description) { %>Summary: <%= description %><% } %>
+
+<% if (license) { %>License: <%= license %><% } %>
+<% if (homepage) { %>URL: <%= homepage %><% } %>
+
+Requires: <%= requires.join(', ') %>
+AutoReqProv: no
+
+
+<% if (productDescription) {
+  %>%description
+<%= productDescription %><% } %>
+
 
 %install
 mkdir -p %{buildroot}/usr/
-<% if (process.platform != 'darwin') { %>cp -r usr/* %{buildroot}/usr/<% } else { %>cp -R usr/* %{buildroot}/usr/<% } %>
+<%= process.platform === 'darwin' ? 'cp -R usr/* %{buildroot}/usr/' : 'cp -r usr/* %{buildroot}/usr/' %>
+
 
 %files
 /usr/bin/<%= name %>
@@ -29,18 +34,21 @@ mkdir -p %{buildroot}/usr/
   %>/usr/share/pixmaps/<%= name %>.png
 <% } %>
 
-<% if (pre) { %>
-%pre
+<% if (pre) {
+  %>%pre
 <%= pre %><% } %>
 
-<% if (preun) { %>
-%preun
+
+<% if (preun) {
+  %>%preun
 <%= preun %><% } %>
 
-<% if (post) { %>
-%post
+
+<% if (post) {
+  %>%post
 <%= post %><% } %>
 
-<% if (postun) { %>
-%postun
+
+<% if (postun) {
+  %>%postun
 <%= postun %><% } %>

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -21,7 +21,7 @@ print('\n\n\n') }
 
 %>%install
 mkdir -p %{buildroot}/usr/
-<%= process.platform === 'darwin' ? 'cp -R usr/* %{buildroot}/usr/' : 'cp -r usr/* %{buildroot}/usr/' %>
+cp <%= process.platform === 'darwin' ? '-R' : '-r' %> usr/* %{buildroot}/usr/
 
 
 %files

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -3,21 +3,23 @@
 Name: <%= name %>
 Version: <%= version %>
 Release: <%= revision %>%{?dist}
-<% if (description) { %>Summary: <%= description %><% } %>
+<% if (description) { print(`Summary: ${description}\n`) }
+%>
+<% if (license) { print(`License: ${license}\n`) }
+if (homepage) { print(`URL: ${homepage}\n`) }
+if (license || homepage) { print('\n') }
 
-<% if (license) { %>License: <%= license %><% } %>
-<% if (homepage) { %>URL: <%= homepage %><% } %>
-
-Requires: <%= requires.join(', ') %>
+%>Requires: <%= requires.join(', ') %>
 AutoReqProv: no
 
 
 <% if (productDescription) {
-  %>%description
-<%= productDescription %><% } %>
+%>%description
+<% print(productDescription)
+print('\n\n\n') }
 
 
-%install
+%>%install
 mkdir -p %{buildroot}/usr/
 <%= process.platform === 'darwin' ? 'cp -R usr/* %{buildroot}/usr/' : 'cp -r usr/* %{buildroot}/usr/' %>
 
@@ -36,19 +38,22 @@ mkdir -p %{buildroot}/usr/
 
 <% if (pre) {
   %>%pre
-<%= pre %><% } %>
+<% print(pre)
+if (preun || post || postun) print('\n\n\n') }
 
 
-<% if (preun) {
+%><% if (preun) {
   %>%preun
-<%= preun %><% } %>
+<% print(preun)
+if (post || postun) print('\n\n\n') }
 
 
-<% if (post) {
+%><% if (post) {
   %>%post
-<%= post %><% } %>
+<% print(post)
+if (postun) print('\n\n\n') }
 
 
-<% if (postun) {
+%><% if (postun) {
   %>%postun
-<%= postun %><% } %>
+<% print(postun) } %>


### PR DESCRIPTION
For both `.ejs` files, I've removed all unnecessary `if` statements, based on options that do have a default so they won't be `undefined`.
For `spec.ejs`, I'm trying to follow [this guide](https://fedoraproject.org/wiki/PeterGordon/SpecFormattingGuidelines) and some other conventions.
One of the requirements, keeping two lines between sections, it's impossible to follow when using lodash. We would have to switch to [`ejs`](https://www.npmjs.com/package/ejs) in order to fine control the spacing between sections.