### PR TITLE
chore: release 3.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,19 @@
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/electron-userland/electron-installer-redhat/compare/v3.0.0...master
+[Unreleased]: https://github.com/electron-userland/electron-installer-redhat/compare/v3.2.0...master
+
+## [3.2.0] - 2020-07-23
+
+[3.2.0]: https://github.com/electron-userland/electron-installer-redhat/compare/v3.1.0...v3.2.0
+
+### Added
+
+* Support for scalable and symbolic icons (#169)
+
+### Fixed
+
+* Conformance to RPM spec formatting guidelines (#171) (see [SpecFormattingGuidelines](https://fedoraproject.org/wiki/PeterGordon/SpecFormattingGuidelines))
 
 ## [3.1.0] - 2020-06-28
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 
 ### Fixed
 
-* Conformance to RPM spec formatting guidelines (#171) (see [SpecFormattingGuidelines](https://fedoraproject.org/wiki/PeterGordon/SpecFormattingGuidelines))
+* Conformance to [RPM spec formatting guidelines](https://fedoraproject.org/wiki/PeterGordon/SpecFormattingGuidelines) (#171)
 
 ## [3.1.0] - 2020-06-28
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-installer-redhat",
   "description": "Create a Red Hat package for your Electron app.",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "MIT",
   "author": {
     "name": "Daniel Perez Alvarez",


### PR DESCRIPTION
If approved, I'll push the tag so we can release a new version. Hopefully, the CI won't have a problem publishing to npm.
Here's the text that could go into the Releases page:

### Added

* Support for scalable and symbolic icons (#169)

### Fixed

* Conformance to [RPM spec formatting guidelines](https://fedoraproject.org/wiki/PeterGordon/SpecFormattingGuidelines) (#171)