### PR TITLE
feat: add option to set %_target_os

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ Default: `undefined`
 
 Machine architecture the package is targeted to, used to set the `--target` option.
 
+#### options.os
+Type: `String`
+Default: Operating system platform of the host machine
+
+Operating system platform the package is targeted to, used to set the `--target` option.
+
 #### options.requires
 Type: `Array[String]`
 Default: The minimum list of packages needed for Electron to run

--- a/src/installer.js
+++ b/src/installer.js
@@ -6,6 +6,7 @@ const debug = require('debug')
 const fs = require('fs-extra')
 const path = require('path')
 const wrap = require('word-wrap')
+const os = require('os')
 
 const redhatDependencies = require('./dependencies')
 const spawn = require('./spawn')
@@ -59,7 +60,7 @@ class RedhatInstaller extends common.ElectronInstaller {
   async createPackage () {
     this.options.logger(`Creating package at ${this.stagingDir}`)
 
-    const output = await spawn('rpmbuild', ['-bb', this.specPath, '--target', this.options.arch, '--define', `_topdir ${this.stagingDir}`], this.options.logger)
+    const output = await spawn('rpmbuild', ['-bb', this.specPath, '--target', `${this.options.arch}-${this.options.vendor}-${this.options.os}`, '--define', `_topdir ${this.stagingDir}`], this.options.logger)
     this.options.logger(`rpmbuild output: ${output}`)
   }
 
@@ -126,6 +127,9 @@ class RedhatInstaller extends common.ElectronInstaller {
     this.options.requires = common.mergeUserSpecified(this.userSupplied, 'requires', this.defaults)
 
     this.normalizeVersion()
+
+    this.options.vendor = 'none'
+    this.options.os = this.options.os || os.platform()
   }
 
   /**

--- a/src/installer.js
+++ b/src/installer.js
@@ -6,7 +6,6 @@ const debug = require('debug')
 const fs = require('fs-extra')
 const path = require('path')
 const wrap = require('word-wrap')
-const os = require('os')
 
 const redhatDependencies = require('./dependencies')
 const spawn = require('./spawn')
@@ -129,7 +128,7 @@ class RedhatInstaller extends common.ElectronInstaller {
     this.normalizeVersion()
 
     this.options.vendor = 'none'
-    this.options.os = this.options.os || os.platform()
+    this.options.os = this.options.os || process.platform
   }
 
   /**

--- a/test/installer.js
+++ b/test/installer.js
@@ -6,6 +6,7 @@ const fs = require('fs-extra')
 const installer = require('..')
 const path = require('path')
 const { spawn } = require('@malept/cross-spawn-promise')
+const os = require('os')
 
 const assertASARRpmExists = outputDir =>
   access(path.join(outputDir, 'footest.x86.rpm'))
@@ -142,6 +143,39 @@ describe('module', function () {
       if (!scripts.every(element => stdout.includes(element))) {
         throw new Error(`Some installation scripts are missing:\n ${stdout}`)
       }
+    }
+  )
+
+  describeInstaller(
+    'with an app with default %_target_os',
+    {
+      src: 'test/fixtures/app-with-asar/',
+      options: {
+        arch: 'x86'
+      }
+    },
+    'generates a `.rpm` package with default %_target_os',
+    async outputDir => {
+      await assertASARRpmExists(outputDir)
+      const stdout = await spawn('rpm', ['-qp', '--qf', '\'%{OS}\'', 'footest.x86.rpm'], { cwd: outputDir })
+      return stdout === os.platform()
+    }
+  )
+
+  describeInstaller(
+    'with an app with %_target_os linux',
+    {
+      src: 'test/fixtures/app-with-asar/',
+      options: {
+        arch: 'x86',
+        os: 'linux'
+      }
+    },
+    'generates a `.rpm` package with linux %_target_os',
+    async outputDir => {
+      await assertASARRpmExists(outputDir)
+      const stdout = await spawn('rpm', ['-qp', '--qf', '\'%{OS}\'', 'footest.x86.rpm'], { cwd: outputDir })
+      return stdout === 'linux'
     }
   )
 })


### PR DESCRIPTION
This PR adds the option to define the `%_target_os` that it is used in the `target` option of rpmbuild.

> --target PLATFORM
    When building the package, interpret PLATFORM as arch-vendor-os and set the macros %_target, %_target_cpu, and %_target_os accordingly.

This PR is related to https://github.com/webtorrent/webtorrent-desktop/issues/1849 as the maintainer uses osx (darwin) to generate linux packages.