### PR TITLE
Allow for two different variants of libgbm and libxcb to better support OpenSuse Leap 15.2

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -7,7 +7,7 @@ const spawn = require('./spawn')
 const dependencyMap = {
   atspi: 'at-spi2-core',
   drm: 'libdrm',
-  gbm: 'mesa-libgbm',
+  gbm: '(mesa-libgbm or libgbm1)',
   gconf: 'GConf2',
   glib2: 'glib2',
   gtk2: 'gtk2',
@@ -19,7 +19,7 @@ const dependencyMap = {
   nss: '(nss or mozilla-nss)',
   trashCli: 'trash-cli',
   uuid: '(libuuid or libuuid1)',
-  xcbDri3: 'libxcb',
+  xcbDri3: '(libxcb or libxcb1)',
   xdgUtils: 'xdg-utils',
   xss: 'libXScrnSaver',
   xtst: '(libXtst or libXtst6)'


### PR DESCRIPTION
On OpenSuse Leap 15.2 (which is the most recent version), [mesa-libgbm](https://software.opensuse.org/package/mesa-libgbm?search_term=mesa-libgbm) and [libxcb](https://software.opensuse.org/package/libxcb) are not valid package names (when you follow the links you see that the repo page says "There is no official package available for ALL Distributions"). Instead you do find [libgbm1](https://software.opensuse.org/package/libgbm1) and [libxcb1](https://software.opensuse.org/package/libxcb1) as valid packages.

This pull request is to make the adjustment in [src/dependencies.js](https://github.com/electron-userland/electron-installer-redhat/blob/060071451a5859a01eaf0724a685aed21bf0762f/src/dependencies.js) by adding the above mentioned package names libgbm1 and libxcb1 as alternatives to the currently defined ones.