### PR TITLE
refactor: rename options.os to options.platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Default: `undefined`
 
 Machine architecture the package is targeted to, used to set the `--target` option.
 
-#### options.os
+#### options.platform
 Type: `String`
 Default: Operating system platform of the host machine. For possible values see Node.js [process.platform](https://nodejs.org/api/process.html#process_process_platform)
 

--- a/README.md
+++ b/README.md
@@ -277,9 +277,9 @@ Machine architecture the package is targeted to, used to set the `--target` opti
 
 #### options.os
 Type: `String`
-Default: Operating system platform of the host machine
+Default: Operating system platform of the host machine. For possible values see Node.js [process.platform](https://nodejs.org/api/process.html#process_process_platform)
 
-Operating system platform the package is targeted to, used to set the `--target` option.
+Operating system platform the package is targeted to, used to set the [`--target`](https://linux.die.net/man/8/rpmbuild) option.
 
 #### options.requires
 Type: `Array[String]`

--- a/src/installer.js
+++ b/src/installer.js
@@ -59,7 +59,7 @@ class RedhatInstaller extends common.ElectronInstaller {
   async createPackage () {
     this.options.logger(`Creating package at ${this.stagingDir}`)
 
-    const output = await spawn('rpmbuild', ['-bb', this.specPath, '--target', `${this.options.arch}-${this.options.vendor}-${this.options.os}`, '--define', `_topdir ${this.stagingDir}`], this.options.logger)
+    const output = await spawn('rpmbuild', ['-bb', this.specPath, '--target', `${this.options.arch}-${this.options.vendor}-${this.options.platform}`, '--define', `_topdir ${this.stagingDir}`], this.options.logger)
     this.options.logger(`rpmbuild output: ${output}`)
   }
 
@@ -128,7 +128,7 @@ class RedhatInstaller extends common.ElectronInstaller {
     this.normalizeVersion()
 
     this.options.vendor = 'none'
-    this.options.os = this.options.os || process.platform
+    this.options.platform = this.options.platform || process.platform
   }
 
   /**

--- a/test/installer.js
+++ b/test/installer.js
@@ -170,7 +170,7 @@ describe('module', function () {
         src: 'test/fixtures/app-with-asar/',
         options: {
           arch: 'x86',
-          os: 'linux'
+          platform: 'linux'
         }
       },
       'generates a `.rpm` package with linux %_target_os',


### PR DESCRIPTION
In #175, we didn't add enough information to the README for the new `options.os` option. This PR fixes that.
@malept let me know if this is enough, I can make any changes you'd like