### PR TITLE
fix: skip stripping when making RPM for different architecture

### DIFF
--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -1,5 +1,9 @@
 %define _binary_payload w<%= compressionLevel %>.xzdio
 
+%if "%{_host_cpu}" != "${_target_cpu}"
+%global __strip /bin/true
+%endif
+
 Name: <%= name %>
 Version: <%= version %>
 Release: <%= revision %>%{?dist}

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -1,6 +1,6 @@
 %define _binary_payload w<%= compressionLevel %>.xzdio
 
-%if "%{_host_cpu}" != "${_target_cpu}"
+%if "%{_host_cpu}" != "%{_target_cpu}"
 %global __strip /bin/true
 %endif
 


### PR DESCRIPTION
By default the host's `/usr/bin/strip` is used, which won't work when executables being stripped are for a different architecture.