### PR TITLE
build: update workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,27 +8,30 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest]
-        node-version: [10.x, 12.x, 14.x]
+        os: [macOS-13, ubuntu-latest]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
 
     steps:
       - name: Install macOS dependencies
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         run: brew install rpm
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
           echo "::set-output name=dir::$(npm config get cache)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
         id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-13, ubuntu-latest]
+        os: [ubuntu-latest]
         node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
 
     steps:


### PR DESCRIPTION
* Kills the macOS jobs for now since `brew install rpm` only supports Ventura and there's no older versions available to install
* Updates permissions for the workflow
* Updates actions and pins SHAs
* Expands test coverage to Node.js 16.x and 18.x