### PR TITLE
fix: builds on rpm>=4.20.0

### DIFF
--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -24,7 +24,7 @@ print('\n\n\n') }
 
 %>%install
 mkdir -p %{buildroot}/usr/
-cp <%= process.platform === 'darwin' ? '-R' : '-r' %> usr/* %{buildroot}/usr/
+cp <%= process.platform === 'darwin' ? '-R' : '-r' %> <%= usrPath %> %{buildroot}/usr/
 
 
 %files

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -33,6 +33,13 @@ async function rpmSupportsBooleanDependencies (logger) {
   return rpmVersionSupportsBooleanDependencies(await getRpmVersion(logger))
 }
 
+/**
+ * Retrieves the RPM version number and determines the path to the `usr` directory based on the version.
+ */
+async function getRpmUsrPath (logger) {
+  return rpmUsrPath(await getRpmVersion(logger))
+}
+
 async function getRpmVersion (logger) {
   const versionOutput = await spawn('rpmbuild', ['--version'], logger)
   return _.last(versionOutput.trim().split(' '))
@@ -46,6 +53,14 @@ async function getRpmVersion (logger) {
 function rpmVersionSupportsBooleanDependencies (rpmVersionString) {
   const rpmVersion = rpmVersionString.split('.').slice(0, 3).map(n => parseInt(n))
   return rpmVersion >= [4, 13, 0]
+}
+
+/**
+ * Determines the path to the `usr` directory based on the RPM version.
+ */
+function rpmUsrPath (rpmVersionString) {
+  const rpmVersion = rpmVersionString.split('.').slice(0, 3).map(n => parseInt(n))
+  return rpmVersion >= [4, 20, 0] ? '../usr/.' : 'usr/*'
 }
 
 /**
@@ -75,6 +90,7 @@ module.exports = {
     }
   },
   getRpmVersion,
+  getRpmUsrPath,
   rpmSupportsBooleanDependencies,
   rpmVersionSupportsBooleanDependencies,
   trashRequiresAsBoolean

--- a/src/installer.js
+++ b/src/installer.js
@@ -91,6 +91,7 @@ class RedhatInstaller extends common.ElectronInstaller {
     ])
     this.defaults = {
       ...common.getDefaultsFromPackageJSON(pkg, { revision: 1 }),
+      usrPath: await redhatDependencies.getRpmUsrPath(this.userSupplied.logger),
       version: pkg.version || '0.0.0',
       license: pkg.license,
       compressionLevel: 2,

--- a/test/fixtures/custom.spec.ejs
+++ b/test/fixtures/custom.spec.ejs
@@ -20,7 +20,7 @@ print('\n\n\n') }
 
 %>%install
 mkdir -p %{buildroot}/usr/
-cp <%= process.platform === 'darwin' ? '-R' : '-r' %> usr/* %{buildroot}/usr/
+cp <%= process.platform === 'darwin' ? '-R' : '-r' %> <%= usrPath %> %{buildroot}/usr/
 
 
 %files


### PR DESCRIPTION
This change introduces support for building with rpm >= 4.20.0 while retaining support for rpm < 4.20.0

Related issue: #343