### PR TITLE
Fix RPM spec install copy path for rpm 4.20+

### DIFF
--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -24,7 +24,7 @@ print('\n\n\n') }
 
 %>%install
 mkdir -p %{buildroot}/usr/
-cp <%= process.platform === 'darwin' ? '-R' : '-r' %> usr/* %{buildroot}/usr/
+cp <%= process.platform === 'darwin' ? '-R' : '-r' %> %{_topdir}/BUILD/usr/* %{buildroot}/usr/
 
 
 %files


### PR DESCRIPTION
Fix %install in spec template to copy from the actual staging build directory Prevents cp: cannot stat 'usr/*' on rpm 4.20+ by using %{_topdir}/BUILD/usr/*