### PR TITLE
feat!: convert to ESM

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
 
 ### Changed
 
+* The package is now an ES module: use `import` instead of `require` (CommonJS consumers on
+  Node.js >= 22.12 can use `require('electron-installer-redhat').default`)
 * Switched package management to Yarn 4
 * Replaced ESLint with `oxlint`
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ $ npm install --save-dev electron-installer-redhat
 And write something like this:
 
 ```javascript
-const installer = require('electron-installer-redhat')
+import installer from 'electron-installer-redhat'
 
 const options = {
   src: 'dist/app-linux-x64/',
@@ -162,19 +162,19 @@ const options = {
   arch: 'x86_64'
 }
 
-async function main (options) {
-  console.log('Creating package (this may take a while)')
+console.log('Creating package (this may take a while)')
 
-  try {
-    await installer(options)
-    console.log(`Successfully created package at ${options.dest}`)
-  } catch (err) {
-    console.error(err, err.stack)
-    process.exit(1)
-  }
+try {
+  await installer(options)
+  console.log(`Successfully created package at ${options.dest}`)
+} catch (err) {
+  console.error(err, err.stack)
+  process.exit(1)
 }
-main(options)
 ```
+
+This package is an [ES module](https://nodejs.org/api/esm.html). On Node.js 22.12 and newer,
+CommonJS code can still load it with `require('electron-installer-redhat').default`.
 
 You'll end up with the package at `dist/installers/app-0.0.1-1.x86_64.rpm`.
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "node": ">= 22.12.0"
   },
   "packageManager": "yarn@4.10.3+sha512.c38cafb5c7bb273f3926d04e55e1d8c9dfa7d9c3ea1f36a4868fa028b9e5f72298f0b7f401ad5eb921749eb012eb1c3bb74bf7503df3ee43fd600d14a018266f",
-  "main": "src/installer.js",
+  "type": "module",
+  "exports": "./src/installer.js",
   "bin": "src/cli.js",
   "scripts": {
     "lint": "oxlint",
@@ -43,13 +44,11 @@
   },
   "devDependencies": {
     "chai": "^4.5.0",
-    "chai-as-promised": "^7.1.1",
     "husky": "^6.0.0",
     "lint-staged": "^10.2.7",
     "mocha": "^10.8.2",
     "oxlint": "^1.59.0",
     "promise-retry": "^2.0.1",
-    "proxyquire": "^2.1.3",
     "sinon": "^11.1.0",
     "tmp-promise": "^3.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
   "exports": "./src/installer.js",
   "bin": "src/cli.js",
   "scripts": {
+    "coverage": "node --test --experimental-test-coverage test/*.js",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "prepare": "husky install",
-    "spec": "mocha",
+    "spec": "node --test test/*.js",
     "test": "yarn lint && yarn spec"
   },
   "dependencies": {
@@ -43,10 +44,9 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "chai": "^4.5.0",
+    "chai": "^6.2.0",
     "husky": "^6.0.0",
     "lint-staged": "^10.2.7",
-    "mocha": "^10.8.2",
     "oxlint": "^1.59.0",
     "promise-retry": "^2.0.1",
     "sinon": "^11.1.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
-const yargs = require('yargs')
-const { hideBin } = require('yargs/helpers')
+import { readFileSync } from 'node:fs'
 
-const installer = require('./installer')
-const pkg = require('../package.json')
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+
+import installer from './installer.js'
+
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)))
 
 const argv = yargs(hideBin(process.argv))
   .version(pkg.version)

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -64,8 +64,8 @@ const dependencies = {
    * RPM does not follow semantic versioning, so `semver` cannot be used.
    */
   rpmVersionSupportsBooleanDependencies (rpmVersionString) {
-    const rpmVersion = rpmVersionString.split('.').slice(0, 3).map(n => parseInt(n))
-    return rpmVersion >= [4, 13, 0]
+    const [major, minor] = rpmVersionString.split('.').slice(0, 3).map(n => parseInt(n) || 0)
+    return major > 4 || (major === 4 && minor >= 13)
   },
 
   /**

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -1,7 +1,6 @@
-'use strict'
+import common from 'electron-installer-common'
 
-const common = require('electron-installer-common')
-const spawn = require('./spawn')
+import spawn from './spawn.js'
 
 const dependencyMap = {
   atspi: 'at-spi2-core',
@@ -24,57 +23,62 @@ const dependencyMap = {
   xtst: '(libXtst or libXtst6)'
 }
 
-/**
- * Retrieves the RPM version number and determines whether it has support for boolean
- * dependencies (>= 4.13.0).
- */
-async function rpmSupportsBooleanDependencies (logger) {
-  return rpmVersionSupportsBooleanDependencies(await getRpmVersion(logger))
-}
-
-async function getRpmVersion (logger) {
-  const versionOutput = await spawn('rpmbuild', ['--version'], logger)
-  return versionOutput.trim().split(' ').at(-1)
-}
-
-/**
- * Determine whether the RPM version string has support for boolean dependencies (>= 4.13.0).
- *
- * RPM does not follow semantic versioning, so `semver` cannot be used.
- */
-function rpmVersionSupportsBooleanDependencies (rpmVersionString) {
-  const rpmVersion = rpmVersionString.split('.').slice(0, 3).map(n => parseInt(n))
-  return rpmVersion >= [4, 13, 0]
-}
-
-/**
- * Transforms the list of trash requires into an RPM boolean dependency list.
- */
-function trashRequiresAsBoolean (electronVersion, dependencyMap) {
-  const trashDepends = common.getTrashDepends(electronVersion, dependencyMap)
-  if (trashDepends.length === 1) {
-    return [trashDepends[0]]
-  } else {
-    return [`(${trashDepends.join(' or ')})`]
-  }
-}
-
-module.exports = {
+const dependencies = {
   dependencyMap,
+
   /**
    * The dependencies for Electron itself, given an Electron version.
    */
   forElectron: async function dependenciesForElectron (electronVersion, logger) {
     const requires = common.getDepends(electronVersion, dependencyMap)
-    if (await module.exports.rpmSupportsBooleanDependencies(logger)) {
-      const trashRequires = trashRequiresAsBoolean(electronVersion, dependencyMap)
+    if (await dependencies.rpmSupportsBooleanDependencies(logger)) {
+      const trashRequires = dependencies.trashRequiresAsBoolean(electronVersion, dependencyMap)
       return { requires: requires.concat(trashRequires) }
     } else {
       throw new Error('Please upgrade to RPM 4.13 or above, which supports boolean dependencies.\nThis is used to express Electron dependencies for a wide variety of RPM-using distributions.')
     }
   },
-  getRpmVersion,
-  rpmSupportsBooleanDependencies,
-  rpmVersionSupportsBooleanDependencies,
-  trashRequiresAsBoolean
+
+  async getRpmVersion (logger) {
+    return dependencies.parseRpmVersionOutput(await spawn('rpmbuild', ['--version'], logger))
+  },
+
+  /**
+   * Extracts the version number from the output of `rpmbuild --version`.
+   */
+  parseRpmVersionOutput (versionOutput) {
+    return versionOutput.trim().split(' ').at(-1)
+  },
+
+  /**
+   * Retrieves the RPM version number and determines whether it has support for boolean
+   * dependencies (>= 4.13.0).
+   */
+  async rpmSupportsBooleanDependencies (logger) {
+    return dependencies.rpmVersionSupportsBooleanDependencies(await dependencies.getRpmVersion(logger))
+  },
+
+  /**
+   * Determine whether the RPM version string has support for boolean dependencies (>= 4.13.0).
+   *
+   * RPM does not follow semantic versioning, so `semver` cannot be used.
+   */
+  rpmVersionSupportsBooleanDependencies (rpmVersionString) {
+    const rpmVersion = rpmVersionString.split('.').slice(0, 3).map(n => parseInt(n))
+    return rpmVersion >= [4, 13, 0]
+  },
+
+  /**
+   * Transforms the list of trash requires into an RPM boolean dependency list.
+   */
+  trashRequiresAsBoolean (electronVersion, dependencyMap) {
+    const trashDepends = common.getTrashDepends(electronVersion, dependencyMap)
+    if (trashDepends.length === 1) {
+      return [trashDepends[0]]
+    } else {
+      return [`(${trashDepends.join(' or ')})`]
+    }
+  }
 }
+
+export default dependencies

--- a/src/installer.js
+++ b/src/installer.js
@@ -1,14 +1,12 @@
-'use strict'
+import common from 'electron-installer-common'
+import debug from 'debug'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import wrap from 'word-wrap'
 
-const common = require('electron-installer-common')
-const debug = require('debug')
-const fs = require('node:fs/promises')
-const path = require('node:path')
-const wrap = require('word-wrap')
-
-const redhatDependencies = require('./dependencies')
-const spawn = require('./spawn')
-const util = require('./util')
+import redhatDependencies from './dependencies.js'
+import spawn from './spawn.js'
+import * as util from './util.js'
 
 const defaultLogger = debug('electron-installer-redhat')
 
@@ -33,11 +31,11 @@ class RedhatInstaller extends common.ElectronInstaller {
   }
 
   get defaultDesktopTemplatePath () {
-    return path.resolve(__dirname, '../resources/desktop.ejs')
+    return path.resolve(import.meta.dirname, '../resources/desktop.ejs')
   }
 
   get defaultSpecTemplatePath () {
-    return path.resolve(__dirname, '../resources/spec.ejs')
+    return path.resolve(import.meta.dirname, '../resources/spec.ejs')
   }
 
   get packagePattern () {
@@ -93,7 +91,7 @@ class RedhatInstaller extends common.ElectronInstaller {
       version: pkg.version || '0.0.0',
       license: pkg.license,
       compressionLevel: 2,
-      icon: path.resolve(__dirname, '../resources/icon.png'),
+      icon: path.resolve(import.meta.dirname, '../resources/icon.png'),
       pre: undefined,
       post: undefined,
       preun: undefined,
@@ -160,7 +158,7 @@ class RedhatInstaller extends common.ElectronInstaller {
 
 /* ************************************************************************** */
 
-module.exports = async data => {
+export default async function createRedhatInstaller (data) {
   data.rename = data.rename || defaultRename
   data.logger = data.logger || defaultLogger
 
@@ -178,4 +176,4 @@ module.exports = async data => {
   return installer.options
 }
 
-module.exports.Installer = RedhatInstaller
+export { RedhatInstaller as Installer }

--- a/src/spawn.js
+++ b/src/spawn.js
@@ -1,7 +1,5 @@
-'use strict'
-
-const { spawn } = require('@malept/cross-spawn-promise')
-const which = require('which')
+import { spawn as crossSpawn } from '@malept/cross-spawn-promise'
+import which from 'which'
 
 function updateExecutableMissingException (err, updateError) {
   if (updateError && err.code === 'ENOENT' && err.syscall === 'spawn rpmbuild') {
@@ -21,8 +19,8 @@ function updateExecutableMissingException (err, updateError) {
   }
 }
 
-module.exports = function (cmd, args, logger) {
-  return spawn(cmd, args, {
+export default function spawn (cmd, args, logger) {
+  return crossSpawn(cmd, args, {
     logger,
     updateErrorCallback: updateExecutableMissingException
   })

--- a/src/util.js
+++ b/src/util.js
@@ -1,13 +1,7 @@
-'use strict'
-
 /**
  * Returns a string containing only characters that are allowed in the version field of RPM spec files
  */
-function replaceInvalidVersionCharacters (version) {
+export function replaceInvalidVersionCharacters (version) {
   version = version || ''
   return version.replace(/[-]/g, '.')
-}
-
-module.exports = {
-  replaceInvalidVersionCharacters: replaceInvalidVersionCharacters
 }

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,3 +1,4 @@
+import { after, before, describe, it } from 'node:test'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
@@ -16,8 +17,7 @@ function runCLI (options) {
   before(() => spawn('./src/cli.js', args))
 }
 
-describe('cli', function () {
-  this.timeout(10000)
+describe('cli', () => {
 
   describe('with an app with asar', () => {
     const outputDir = tempOutputDir()

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,14 +1,9 @@
-'use strict'
+import fs from 'node:fs/promises'
+import path from 'node:path'
 
-const fs = require('node:fs/promises')
-const path = require('node:path')
-
-const access = require('./helpers/access')
-const describeInstaller = require('./helpers/describe_installer')
-const spawn = require('../src/spawn')
-
-const tempOutputDir = describeInstaller.tempOutputDir
-const cleanupOutputDir = describeInstaller.cleanupOutputDir
+import access from './helpers/access.js'
+import { cleanupOutputDir, tempOutputDir } from './helpers/describe_installer.js'
+import spawn from '../src/spawn.js'
 
 function runCLI (options) {
   const args = [

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -1,3 +1,4 @@
+import { afterEach, describe, it } from 'node:test'
 import assert from 'node:assert'
 
 import { expect } from 'chai'

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -51,6 +51,12 @@ describe('dependencies', () => {
     it('works with 4 part versions (1.2.3.4)', () => {
       expect(dependencies.rpmVersionSupportsBooleanDependencies('4.1.12.2')).to.equal(false)
     })
+
+    it('compares version components numerically, not lexicographically', () => {
+      expect(dependencies.rpmVersionSupportsBooleanDependencies('4.9.0')).to.equal(false)
+      expect(dependencies.rpmVersionSupportsBooleanDependencies('4.13.0')).to.equal(true)
+      expect(dependencies.rpmVersionSupportsBooleanDependencies('5.0.0')).to.equal(true)
+    })
   })
 
   describe('trashRequiresAsBoolean', () => {

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -1,10 +1,9 @@
-const chaiAsPromised = require('chai-as-promised')
-const dependencies = require('../src/dependencies')
-const { expect, use } = require('chai')
-const proxyquire = require('proxyquire').noPreserveCache()
-const sinon = require('sinon')
+import assert from 'node:assert'
 
-use(chaiAsPromised)
+import { expect } from 'chai'
+import sinon from 'sinon'
+
+import dependencies from '../src/dependencies.js'
 
 describe('dependencies', () => {
   describe('forElectron', () => {
@@ -14,32 +13,28 @@ describe('dependencies', () => {
 
     it('uses an RPM that does not support boolean dependencies', async () => {
       sinon.stub(dependencies, 'rpmSupportsBooleanDependencies').resolves(false)
-      await expect(dependencies.forElectron('v1.0.0')).to.eventually.be.rejectedWith(/^Please upgrade to RPM 4\.13/)
+      await assert.rejects(dependencies.forElectron('v1.0.0'), /^Error: Please upgrade to RPM 4\.13/)
     })
 
     it('uses an RPM that supports boolean dependencies', async () => {
       sinon.stub(dependencies, 'rpmSupportsBooleanDependencies').resolves(true)
-      await expect(dependencies.forElectron('v1.0.0')).to.be.fulfilled // eslint-disable-line no-unused-expressions
+      await assert.doesNotReject(dependencies.forElectron('v1.0.0'))
     })
   })
 
   describe('getRpmVersion', () => {
-    function stubGetRpmVersion (versionOutput) {
-      const { getRpmVersion } = proxyquire('../src/dependencies', {
-        './spawn': async () => Promise.resolve(versionOutput)
-      })
+    it('returns the version of the installed rpmbuild', async () => {
+      expect(await dependencies.getRpmVersion(null)).to.match(/^\d+(\.\d+)+/)
+    })
+  })
 
-      return getRpmVersion
-    }
-
-    it('parses version output from RPM < 4.15', async () => {
-      const getRpmVersion = stubGetRpmVersion('RPM version 4.14.2.1\n')
-      await expect(getRpmVersion(null)).to.eventually.equal('4.14.2.1')
+  describe('parseRpmVersionOutput', () => {
+    it('parses version output from RPM < 4.15', () => {
+      expect(dependencies.parseRpmVersionOutput('RPM version 4.14.2.1\n')).to.equal('4.14.2.1')
     })
 
-    it('parses version output from RPM >= 4.15', async () => {
-      const getRpmVersion = stubGetRpmVersion('RPM-Version 4.15.1\n')
-      await expect(getRpmVersion(null)).to.eventually.equal('4.15.1')
+    it('parses version output from RPM >= 4.15', () => {
+      expect(dependencies.parseRpmVersionOutput('RPM-Version 4.15.1\n')).to.equal('4.15.1')
     })
   })
 

--- a/test/helpers/access.js
+++ b/test/helpers/access.js
@@ -1,12 +1,10 @@
-'use strict'
-
-const fs = require('node:fs/promises')
-const retry = require('promise-retry')
+import fs from 'node:fs/promises'
+import retry from 'promise-retry'
 
 /**
  * `fs.access` which retries three times.
  */
-module.exports = function (path) {
+export default function access (path) {
   return retry(retry => {
     return fs.access(path)
       .catch(retry)

--- a/test/helpers/describe_installer.js
+++ b/test/helpers/describe_installer.js
@@ -1,3 +1,4 @@
+import { after, before, describe, it } from 'node:test'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'

--- a/test/helpers/describe_installer.js
+++ b/test/helpers/describe_installer.js
@@ -1,45 +1,42 @@
-'use strict'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 
-const fs = require('node:fs/promises')
-const os = require('node:os')
-const path = require('node:path')
-const tmp = require('tmp-promise')
+import tmp from 'tmp-promise'
 
-const installer = require('../..')
+import installer from '../../src/installer.js'
 
-module.exports = {
-  describeInstaller: function describeInstaller (description, installerOptions, itDescription, itFunc) {
-    describe(description, () => {
-      const outputDir = module.exports.tempOutputDir(installerOptions.dest)
-      const options = module.exports.testInstallerOptions(outputDir, installerOptions)
+export function describeInstaller (description, installerOptions, itDescription, itFunc) {
+  describe(description, () => {
+    const outputDir = tempOutputDir(installerOptions.dest)
+    const options = testInstallerOptions(outputDir, installerOptions)
 
-      before(async () => installer(options))
+    before(async () => installer(options))
 
-      it(itDescription, () => itFunc(outputDir))
+    it(itDescription, () => itFunc(outputDir))
 
-      module.exports.cleanupOutputDir(outputDir)
-    })
-  },
+    cleanupOutputDir(outputDir)
+  })
+}
 
-  cleanupOutputDir: function cleanupOutputDir (outputDir) {
-    after(async () => fs.rm(outputDir, { recursive: true, force: true }))
-  },
+export function cleanupOutputDir (outputDir) {
+  after(async () => fs.rm(outputDir, { recursive: true, force: true }))
+}
 
-  tempOutputDir: function tempOutputDir (customDir) {
-    return customDir ? path.join(os.tmpdir(), customDir) : tmp.tmpNameSync({ prefix: 'electron-installer-redhat-' })
-  },
+export function tempOutputDir (customDir) {
+  return customDir ? path.join(os.tmpdir(), customDir) : tmp.tmpNameSync({ prefix: 'electron-installer-redhat-' })
+}
 
-  testInstallerOptions: function testInstallerOptions (outputDir, installerOptions) {
-    return {
-      rename: rpmFile => {
-        return path.join(rpmFile, '<%= name %>.<%= arch %>.rpm')
-      },
-      ...installerOptions,
-      options: {
-        arch: 'x86_64',
-        ...installerOptions.options
-      },
-      dest: outputDir
-    }
+export function testInstallerOptions (outputDir, installerOptions) {
+  return {
+    rename: rpmFile => {
+      return path.join(rpmFile, '<%= name %>.<%= arch %>.rpm')
+    },
+    ...installerOptions,
+    options: {
+      arch: 'x86_64',
+      ...installerOptions.options
+    },
+    dest: outputDir
   }
 }

--- a/test/installer.js
+++ b/test/installer.js
@@ -1,3 +1,4 @@
+import { after, before, describe, it } from 'node:test'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
@@ -25,8 +26,7 @@ const recreateDir = async dir => {
   await fs.mkdir(dir, { recursive: true })
 }
 
-describe('module', function () {
-  this.timeout(10000)
+describe('module', () => {
 
   describeInstaller(
     'with an app with asar',

--- a/test/installer.js
+++ b/test/installer.js
@@ -1,11 +1,12 @@
-'use strict'
+import fs from 'node:fs/promises'
+import path from 'node:path'
 
-const access = require('./helpers/access')
-const { describeInstaller, tempOutputDir, testInstallerOptions } = require('./helpers/describe_installer')
-const fs = require('node:fs/promises')
-const installer = require('..')
-const path = require('node:path')
-const { spawn } = require('@malept/cross-spawn-promise')
+import { spawn } from '@malept/cross-spawn-promise'
+
+import installer from '../src/installer.js'
+
+import access from './helpers/access.js'
+import { describeInstaller, tempOutputDir, testInstallerOptions } from './helpers/describe_installer.js'
 
 const assertASARRpmExists = outputDir =>
   access(path.join(outputDir, 'footest.x86.rpm'))

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -1,7 +1,6 @@
-'use strict'
+import chai from 'chai'
 
-const chai = require('chai')
-const spawn = require('../src/spawn')
+import spawn from '../src/spawn.js'
 
 describe('spawn', () => {
   let oldPath

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -1,4 +1,5 @@
-import chai from 'chai'
+import { after, before, describe, it } from 'node:test'
+import { expect } from 'chai'
 
 import spawn from '../src/spawn.js'
 
@@ -15,7 +16,7 @@ describe('spawn', () => {
       await spawn('rpmbuild', ['--version'], () => { })
       throw new Error('rpmbuild should not have been executed')
     } catch (error) {
-      chai.expect(error.message).to.match(/Error executing command \(rpmbuild --version\):\nYour system is missing the rpm/)
+      expect(error.message).to.match(/Error executing command \(rpmbuild --version\):\nYour system is missing the rpm/)
     }
   })
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,3 +1,4 @@
+import { describe, it } from 'node:test'
 import { expect } from 'chai'
 
 import { replaceInvalidVersionCharacters } from '../src/util.js'

--- a/test/util.js
+++ b/test/util.js
@@ -1,5 +1,6 @@
-const { expect } = require('chai')
-const { replaceInvalidVersionCharacters } = require('../src/util')
+import { expect } from 'chai'
+
+import { replaceInvalidVersionCharacters } from '../src/util.js'
 
 describe('private utility functions', function () {
   describe('replaceInvalidVersionCharacters', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -446,17 +446,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chai-as-promised@npm:^7.1.1":
-  version: 7.1.2
-  resolution: "chai-as-promised@npm:7.1.2"
-  dependencies:
-    check-error: "npm:^1.0.2"
-  peerDependencies:
-    chai: ">= 2.1.2 < 6"
-  checksum: 10c0/ee20ed75296d8cbf828b2f3c9ad64627cee67b1a38b8e906ca59fe788fb6965ddb10f702ae66645ed88f15a905ade4f2d9f8540029e92e2d59b229c9f912273f
-  languageName: node
-  linkType: hard
-
 "chai@npm:^4.5.0":
   version: 4.5.0
   resolution: "chai@npm:4.5.0"
@@ -482,7 +471,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"check-error@npm:^1.0.2, check-error@npm:^1.0.3":
+"check-error@npm:^1.0.3":
   version: 1.0.3
   resolution: "check-error@npm:1.0.3"
   dependencies:
@@ -702,7 +691,6 @@ __metadata:
   dependencies:
     "@malept/cross-spawn-promise": "npm:^2.0.0"
     chai: "npm:^4.5.0"
-    chai-as-promised: "npm:^7.1.1"
     debug: "npm:^4.1.1"
     electron-installer-common: "npm:^0.10.3"
     husky: "npm:^6.0.0"
@@ -710,7 +698,6 @@ __metadata:
     mocha: "npm:^10.8.2"
     oxlint: "npm:^1.59.0"
     promise-retry: "npm:^2.0.1"
-    proxyquire: "npm:^2.1.3"
     sinon: "npm:^11.1.0"
     tmp-promise: "npm:^3.0.2"
     which: "npm:^5.0.0"
@@ -777,13 +764,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-errors@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "es-errors@npm:1.3.0"
-  checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
-  languageName: node
-  linkType: hard
-
 "escalade@npm:^3.1.1":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
@@ -831,16 +811,6 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10c0/e345083c4306b3aed6cb8ec551e26c36bab5c511e99ea4576a16750ddc8d3240e63826cc624f5ae17ad4dc82e68a253213b60d556c11bfad064b7607847ed07f
-  languageName: node
-  linkType: hard
-
-"fill-keys@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "fill-keys@npm:1.0.2"
-  dependencies:
-    is-object: "npm:~1.0.1"
-    merge-descriptors: "npm:~1.0.0"
-  checksum: 10c0/39d01c6d1fbb7cbb05ccbfee5746afcb03dbaf8990f09f3b1b23a144d215c0b685b9db8f40b0e949627e49baa8e5530a1b7f9a2c50ef29acc715a91c45bbb6da
   languageName: node
   linkType: hard
 
@@ -907,13 +877,6 @@ __metadata:
   dependencies:
     node-gyp: "npm:latest"
   conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"function-bind@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "function-bind@npm:1.1.2"
-  checksum: 10c0/d8680ee1e5fcd4c197e4ac33b2b4dce03c71f4d91717292785703db200f5c21f977c568d28061226f9b5900cbcd2c84463646134fd5337e7925e0942bc3f46d5
   languageName: node
   linkType: hard
 
@@ -1004,15 +967,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hasown@npm:^2.0.3":
-  version: 2.0.4
-  resolution: "hasown@npm:2.0.4"
-  dependencies:
-    function-bind: "npm:^1.1.2"
-  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
-  languageName: node
-  linkType: hard
-
 "he@npm:^1.2.0":
   version: 1.2.0
   resolution: "he@npm:1.2.0"
@@ -1088,15 +1042,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.16.1":
-  version: 2.16.2
-  resolution: "is-core-module@npm:2.16.2"
-  dependencies:
-    hasown: "npm:^2.0.3"
-  checksum: 10c0/14b4258390283709c15476d023ec173e27458d5d014ccdb8ed39d576e551c3fa45498b7c9fe178f1529c4cb2648ddd58852a6a62107a019f6e349529f277518a
-  languageName: node
-  linkType: hard
-
 "is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
@@ -1131,13 +1076,6 @@ __metadata:
   version: 1.0.1
   resolution: "is-obj@npm:1.0.1"
   checksum: 10c0/5003acba0af7aa47dfe0760e545a89bbac89af37c12092c3efadc755372cdaec034f130e7a3653a59eb3c1843cfc72ca71eaf1a6c3bafe5a0bab3611a47f9945
-  languageName: node
-  linkType: hard
-
-"is-object@npm:~1.0.1":
-  version: 1.0.2
-  resolution: "is-object@npm:1.0.2"
-  checksum: 10c0/9cfb80c3a850f453d4a77297e0556bc2040ac6bea5b6e418aee208654938b36bab768169bef3945ccfac7a9bb460edd8034e7c6d8973bcf147d7571e1b53e764
   languageName: node
   linkType: hard
 
@@ -1342,13 +1280,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-descriptors@npm:~1.0.0":
-  version: 1.0.3
-  resolution: "merge-descriptors@npm:1.0.3"
-  checksum: 10c0/866b7094afd9293b5ea5dcd82d71f80e51514bed33b4c4e9f516795dc366612a4cbb4dc94356e943a8a6914889a914530badff27f397191b9b75cda20b6bae93
-  languageName: node
-  linkType: hard
-
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -1435,13 +1366,6 @@ __metadata:
     _mocha: bin/_mocha
     mocha: bin/mocha.js
   checksum: 10c0/1f786290a32a1c234f66afe2bfcc68aa50fe9c7356506bd39cca267efb0b4714a63a0cb333815578d63785ba2fba058bf576c2512db73997c0cae0d659a88beb
-  languageName: node
-  linkType: hard
-
-"module-not-found-error@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "module-not-found-error@npm:1.0.1"
-  checksum: 10c0/e57250016b320ef9d0e0037fdb63fb279ca93100a0cee3ef6e90139cbec734215be4a70857dfc0d62ee353d9f8126d2882aa0a80dba49b69292901263a21ea69
   languageName: node
   linkType: hard
 
@@ -1684,13 +1608,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-parse@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "path-parse@npm:1.0.7"
-  checksum: 10c0/11ce261f9d294cc7a58d6a574b7f1b935842355ec66fba3c3fd79e0f036462eaf07d0aa95bb74ff432f9afef97ce1926c720988c6a7451d8a584930ae7de86e1
-  languageName: node
-  linkType: hard
-
 "path-to-regexp@npm:^6.2.1":
   version: 6.3.0
   resolution: "path-to-regexp@npm:6.3.0"
@@ -1759,17 +1676,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxyquire@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "proxyquire@npm:2.1.3"
-  dependencies:
-    fill-keys: "npm:^1.0.2"
-    module-not-found-error: "npm:^1.0.1"
-    resolve: "npm:^1.11.1"
-  checksum: 10c0/f2e57670ed57ef047720516f0ad2f88bfdba4aaa54139bf5d7fe6ec84bf91ec932f402c56439b44d3596743fd9405be4aac99a924eb897e3396c5be1a81672b0
-  languageName: node
-  linkType: hard
-
 "pump@npm:^3.0.0":
   version: 3.0.4
   resolution: "pump@npm:3.0.4"
@@ -1809,34 +1715,6 @@ __metadata:
   version: 4.0.0
   resolution: "resolve-from@npm:4.0.0"
   checksum: 10c0/8408eec31a3112ef96e3746c37be7d64020cda07c03a920f5024e77290a218ea758b26ca9529fd7b1ad283947f34b2291c1c0f6aa0ed34acfdda9c6014c8d190
-  languageName: node
-  linkType: hard
-
-"resolve@npm:^1.11.1":
-  version: 1.22.12
-  resolution: "resolve@npm:1.22.12"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    is-core-module: "npm:^2.16.1"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10c0/b16dc9b537c02e8c3388f7d3dcff9741d3071625f9a97ac1c885f2b0ca51e78df22328fb6d6ef214dd9101fb7cfc19aa2836fe3410402a94f3f7b8639c7149bf
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@npm%3A^1.11.1#optional!builtin<compat/resolve>":
-  version: 1.22.12
-  resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    is-core-module: "npm:^2.16.1"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10c0/fc6519984ae1f894d877c0060ba8b1f5ba3bc0e85a02f74e141929c118c23d74d9735619a9cc2965397387e514884245c65d72a40731dcb6cfc84c7bcdc8321e
   languageName: node
   linkType: hard
 
@@ -2051,13 +1929,6 @@ __metadata:
   dependencies:
     has-flag: "npm:^4.0.0"
   checksum: 10c0/ea1d3c275dd604c974670f63943ed9bd83623edc102430c05adb8efc56ba492746b6e95386e7831b872ec3807fd89dd8eb43f735195f37b5ec343e4234cc7e89
-  languageName: node
-  linkType: hard
-
-"supports-preserve-symlinks-flag@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
-  checksum: 10c0/6c4032340701a9950865f7ae8ef38578d8d7053f5e10518076e6554a9381fa91bd9c6850193695c141f32b21f979c985db07265a758867bac95de05f7d8aeb39
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,15 +36,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/fs-minipass@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "@isaacs/fs-minipass@npm:4.0.1"
-  dependencies:
-    minipass: "npm:^7.0.4"
-  checksum: 10c0/c25b6dc1598790d5b55c0947a9b7d111cfa92594db5296c3b907e2f533c033666f692a3939eadac17b1c7c40d362d0b0635dc874cbfe3e70db7c2b07cc97a5d2
-  languageName: node
-  linkType: hard
-
 "@malept/cross-spawn-promise@npm:^1.0.0":
   version: 1.1.1
   resolution: "@malept/cross-spawn-promise@npm:1.1.1"
@@ -275,13 +266,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abbrev@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "abbrev@npm:5.0.0"
-  checksum: 10c0/8e88f5c798ea4562d28c5a3e9ad69e3879890bc5d695d8f2dffb8609be4c890aacc8f80ef4553fdd2c6a62d70c2ce8bc57b38074e383beb7487bdafa9ed42ea5
-  languageName: node
-  linkType: hard
-
 "aggregate-error@npm:^3.0.0":
   version: 3.1.0
   resolution: "aggregate-error@npm:3.1.0"
@@ -292,7 +276,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-colors@npm:^4.1.1, ansi-colors@npm:^4.1.3":
+"ansi-colors@npm:^4.1.1":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
   checksum: 10c0/ec87a2f59902f74e61eada7f6e6fe20094a628dab765cfdbd03c3477599368768cffccdb5d3bb19a1b6c99126783a143b1fee31aab729b31ffe5836c7e5e28b9
@@ -338,30 +322,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anymatch@npm:~3.1.2":
-  version: 3.1.3
-  resolution: "anymatch@npm:3.1.3"
-  dependencies:
-    normalize-path: "npm:^3.0.0"
-    picomatch: "npm:^2.0.4"
-  checksum: 10c0/57b06ae984bc32a0d22592c87384cd88fe4511b1dd7581497831c56d41939c8a001b28e7b853e1450f2bf61992dfcaa8ae2d0d161a0a90c4fb631ef07098fbac
-  languageName: node
-  linkType: hard
-
-"argparse@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "argparse@npm:2.0.1"
-  checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
-  languageName: node
-  linkType: hard
-
-"assertion-error@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "assertion-error@npm:1.1.0"
-  checksum: 10c0/25456b2aa333250f01143968e02e4884a34588a8538fbbf65c91a637f1dbfb8069249133cd2f4e530f10f624d206a664e7df30207830b659e9f5298b00a4099b
-  languageName: node
-  linkType: hard
-
 "astral-regex@npm:^2.0.0":
   version: 2.0.0
   resolution: "astral-regex@npm:2.0.0"
@@ -390,13 +350,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"binary-extensions@npm:^2.0.0":
-  version: 2.3.0
-  resolution: "binary-extensions@npm:2.3.0"
-  checksum: 10c0/75a59cafc10fb12a11d510e77110c6c7ae3f4ca22463d52487709ca7f18f69d886aa387557cc9864fbdb10153d0bdb4caacabf11541f55e89ed6e18d12ece2b5
-  languageName: node
-  linkType: hard
-
 "brace-expansion@npm:^1.1.7":
   version: 1.1.15
   resolution: "brace-expansion@npm:1.1.15"
@@ -407,28 +360,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.1":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
-  languageName: node
-  linkType: hard
-
-"braces@npm:^3.0.3, braces@npm:~3.0.2":
+"braces@npm:^3.0.3":
   version: 3.0.3
   resolution: "braces@npm:3.0.3"
   dependencies:
     fill-range: "npm:^7.1.1"
   checksum: 10c0/7c6dfd30c338d2997ba77500539227b9d1f85e388a5f43220865201e407e076783d0881f2d297b9f80951b4c957fcf0b51c1d2d24227631643c3f7c284b0aa04
-  languageName: node
-  linkType: hard
-
-"browser-stdout@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "browser-stdout@npm:1.3.1"
-  checksum: 10c0/c40e482fd82be872b6ea7b9f7591beafbf6f5ba522fe3dade98ba1573a1c29a11101564993e4eb44e5488be8f44510af072df9a9637c739217eb155ceb639205
   languageName: node
   linkType: hard
 
@@ -439,25 +376,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^6.0.0":
-  version: 6.3.0
-  resolution: "camelcase@npm:6.3.0"
-  checksum: 10c0/0d701658219bd3116d12da3eab31acddb3f9440790c0792e0d398f0a520a6a4058018e546862b6fba89d7ae990efaeb97da71e1913e9ebf5a8b5621a3d55c710
-  languageName: node
-  linkType: hard
-
-"chai@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "chai@npm:4.5.0"
-  dependencies:
-    assertion-error: "npm:^1.1.0"
-    check-error: "npm:^1.0.3"
-    deep-eql: "npm:^4.1.3"
-    get-func-name: "npm:^2.0.2"
-    loupe: "npm:^2.3.6"
-    pathval: "npm:^1.1.1"
-    type-detect: "npm:^4.1.0"
-  checksum: 10c0/b8cb596bd1aece1aec659e41a6e479290c7d9bee5b3ad63d2898ad230064e5b47889a3bc367b20100a0853b62e026e2dc514acf25a3c9385f936aa3614d4ab4d
+"chai@npm:^6.2.0":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
   languageName: node
   linkType: hard
 
@@ -468,41 +390,6 @@ __metadata:
     ansi-styles: "npm:^4.1.0"
     supports-color: "npm:^7.1.0"
   checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
-  languageName: node
-  linkType: hard
-
-"check-error@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "check-error@npm:1.0.3"
-  dependencies:
-    get-func-name: "npm:^2.0.2"
-  checksum: 10c0/94aa37a7315c0e8a83d0112b5bfb5a8624f7f0f81057c73e4707729cdd8077166c6aefb3d8e2b92c63ee130d4a2ff94bad46d547e12f3238cc1d78342a973841
-  languageName: node
-  linkType: hard
-
-"chokidar@npm:^3.5.3":
-  version: 3.6.0
-  resolution: "chokidar@npm:3.6.0"
-  dependencies:
-    anymatch: "npm:~3.1.2"
-    braces: "npm:~3.0.2"
-    fsevents: "npm:~2.3.2"
-    glob-parent: "npm:~5.1.2"
-    is-binary-path: "npm:~2.1.0"
-    is-glob: "npm:~4.0.1"
-    normalize-path: "npm:~3.0.0"
-    readdirp: "npm:~3.6.0"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: 10c0/8361dcd013f2ddbe260eacb1f3cb2f2c6f2b0ad118708a343a5ed8158941a39cb8fb1d272e0f389712e74ee90ce8ba864eece9e0e62b9705cb468a2f6d917462
-  languageName: node
-  linkType: hard
-
-"chownr@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "chownr@npm:3.0.0"
-  checksum: 10c0/43925b87700f7e3893296c8e9c56cc58f926411cce3a6e5898136daaf08f08b9a8eb76d37d3267e707d0dcc17aed2e2ebdf5848c0c3ce95cf910a919935c1b10
   languageName: node
   linkType: hard
 
@@ -529,17 +416,6 @@ __metadata:
     slice-ansi: "npm:^3.0.0"
     string-width: "npm:^4.2.0"
   checksum: 10c0/dfaa3df675bcef7a3254773de768712b590250420345a4c7ac151f041a4bacb4c25864b1377bee54a39b5925a030c00eabf014e312e3a4ac130952ed3b3879e9
-  languageName: node
-  linkType: hard
-
-"cliui@npm:^7.0.2":
-  version: 7.0.4
-  resolution: "cliui@npm:7.0.4"
-  dependencies:
-    string-width: "npm:^4.2.0"
-    strip-ansi: "npm:^6.0.0"
-    wrap-ansi: "npm:^7.0.0"
-  checksum: 10c0/6035f5daf7383470cef82b3d3db00bec70afb3423538c50394386ffbbab135e26c3689c41791f911fa71b62d13d3863c712fdd70f0fbdffd938a1e6fd09aac00
   languageName: node
   linkType: hard
 
@@ -622,7 +498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.1.1, debug@npm:^4.2.0, debug@npm:^4.3.5":
+"debug@npm:^4.1.1, debug@npm:^4.2.0":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -634,13 +510,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decamelize@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "decamelize@npm:4.0.0"
-  checksum: 10c0/e06da03fc05333e8cd2778c1487da67ffbea5b84e03ca80449519b8fa61f888714bbc6f459ea963d5641b4aa98832130eb5cd193d90ae9f0a27eee14be8e278d
-  languageName: node
-  linkType: hard
-
 "dedent@npm:^0.7.0":
   version: 0.7.0
   resolution: "dedent@npm:0.7.0"
@@ -648,16 +517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deep-eql@npm:^4.1.3":
-  version: 4.1.4
-  resolution: "deep-eql@npm:4.1.4"
-  dependencies:
-    type-detect: "npm:^4.0.0"
-  checksum: 10c0/264e0613493b43552fc908f4ff87b8b445c0e6e075656649600e1b8a17a57ee03e960156fce7177646e4d2ddaf8e5ee616d76bd79929ff593e5c79e4e5e6c517
-  languageName: node
-  linkType: hard
-
-"diff@npm:^5.0.0, diff@npm:^5.2.0":
+"diff@npm:^5.0.0":
   version: 5.2.2
   resolution: "diff@npm:5.2.2"
   checksum: 10c0/52da594c54e9033423da26984b1449ae6accd782d5afc4431c9a192a8507ddc83120fe8f925d7220b9da5b5963c7b6f5e46add3660a00cb36df7a13420a09d4b
@@ -690,12 +550,11 @@ __metadata:
   resolution: "electron-installer-redhat@workspace:."
   dependencies:
     "@malept/cross-spawn-promise": "npm:^2.0.0"
-    chai: "npm:^4.5.0"
+    chai: "npm:^6.2.0"
     debug: "npm:^4.1.1"
     electron-installer-common: "npm:^0.10.3"
     husky: "npm:^6.0.0"
     lint-staged: "npm:^10.2.7"
-    mocha: "npm:^10.8.2"
     oxlint: "npm:^1.59.0"
     promise-retry: "npm:^2.0.1"
     sinon: "npm:^11.1.0"
@@ -741,13 +600,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"env-paths@npm:^2.2.0":
-  version: 2.2.1
-  resolution: "env-paths@npm:2.2.1"
-  checksum: 10c0/285325677bf00e30845e330eec32894f5105529db97496ee3f598478e50f008c5352a41a30e5e72ec9de8a542b5a570b85699cd63bd2bc646dbcb9f311d83bc4
-  languageName: node
-  linkType: hard
-
 "err-code@npm:^2.0.2":
   version: 2.0.3
   resolution: "err-code@npm:2.0.3"
@@ -771,13 +623,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-string-regexp@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "escape-string-regexp@npm:4.0.0"
-  checksum: 10c0/9497d4dd307d845bd7f75180d8188bb17ea8c151c1edbf6b6717c100e104d629dc2dfb687686181b0f4b7d732c7dfdc4d5e7a8ff72de1b0ca283a75bbb3a9cd9
-  languageName: node
-  linkType: hard
-
 "execa@npm:^4.1.0":
   version: 4.1.0
   resolution: "execa@npm:4.1.0"
@@ -795,50 +640,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"exponential-backoff@npm:^3.1.1":
-  version: 3.1.3
-  resolution: "exponential-backoff@npm:3.1.3"
-  checksum: 10c0/77e3ae682b7b1f4972f563c6dbcd2b0d54ac679e62d5d32f3e5085feba20483cf28bd505543f520e287a56d4d55a28d7874299941faf637e779a1aa5994d1267
-  languageName: node
-  linkType: hard
-
-"fdir@npm:^6.5.0":
-  version: 6.5.0
-  resolution: "fdir@npm:6.5.0"
-  peerDependencies:
-    picomatch: ^3 || ^4
-  peerDependenciesMeta:
-    picomatch:
-      optional: true
-  checksum: 10c0/e345083c4306b3aed6cb8ec551e26c36bab5c511e99ea4576a16750ddc8d3240e63826cc624f5ae17ad4dc82e68a253213b60d556c11bfad064b7607847ed07f
-  languageName: node
-  linkType: hard
-
 "fill-range@npm:^7.1.1":
   version: 7.1.1
   resolution: "fill-range@npm:7.1.1"
   dependencies:
     to-regex-range: "npm:^5.0.1"
   checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
-  languageName: node
-  linkType: hard
-
-"find-up@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "find-up@npm:5.0.0"
-  dependencies:
-    locate-path: "npm:^6.0.0"
-    path-exists: "npm:^4.0.0"
-  checksum: 10c0/062c5a83a9c02f53cdd6d175a37ecf8f87ea5bbff1fdfb828f04bfa021441bc7583e8ebc0872a4c1baab96221fb8a8a275a19809fb93fbc40bd69ec35634069a
-  languageName: node
-  linkType: hard
-
-"flat@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "flat@npm:5.0.2"
-  bin:
-    flat: cli.js
-  checksum: 10c0/f178b13482f0cd80c7fede05f4d10585b1f2fdebf26e12edc138e32d3150c6ea6482b7f12813a1091143bad52bb6d3596bca51a162257a21163c0ff438baa5fe
   languageName: node
   linkType: hard
 
@@ -861,25 +668,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.2":
-  version: 2.3.3
-  resolution: "fsevents@npm:2.3.3"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
-  version: 2.3.3
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
-  dependencies:
-    node-gyp: "npm:latest"
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
 "get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
@@ -891,13 +679,6 @@ __metadata:
   version: 1.6.0
   resolution: "get-east-asian-width@npm:1.6.0"
   checksum: 10c0/7e72e9550fd49ca5b246f9af6bb2afc129c96412845ff6556b3274fd44817a381702ca17028efe9866b261a3d44254cbf21e6c90cf05b4b61675630af776d431
-  languageName: node
-  linkType: hard
-
-"get-func-name@npm:^2.0.1, get-func-name@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "get-func-name@npm:2.0.2"
-  checksum: 10c0/89830fd07623fa73429a711b9daecdb304386d237c71268007f788f113505ef1d4cc2d0b9680e072c5082490aec9df5d7758bf5ac6f1c37062855e8e3dc0b9df
   languageName: node
   linkType: hard
 
@@ -917,15 +698,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:~5.1.2":
-  version: 5.1.2
-  resolution: "glob-parent@npm:5.1.2"
-  dependencies:
-    is-glob: "npm:^4.0.1"
-  checksum: 10c0/cab87638e2112bee3f839ef5f6e0765057163d39c66be8ec1602f3823da4692297ad4e972de876ea17c44d652978638d2fd583c6713d0eb6591706825020c9ee
-  languageName: node
-  linkType: hard
-
 "glob@npm:^7.1.4, glob@npm:^7.1.6":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -940,20 +712,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "glob@npm:8.1.0"
-  dependencies:
-    fs.realpath: "npm:^1.0.0"
-    inflight: "npm:^1.0.4"
-    inherits: "npm:2"
-    minimatch: "npm:^5.0.1"
-    once: "npm:^1.3.0"
-  checksum: 10c0/cb0b5cab17a59c57299376abe5646c7070f8acb89df5595b492dba3bfb43d301a46c01e5695f01154e6553168207cb60d4eaf07d3be4bc3eb9b0457c5c561d0f
-  languageName: node
-  linkType: hard
-
-"graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -964,15 +723,6 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
-  languageName: node
-  linkType: hard
-
-"he@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "he@npm:1.2.0"
-  bin:
-    he: bin/he
-  checksum: 10c0/a27d478befe3c8192f006cdd0639a66798979dfa6e2125c6ac582a19a5ebfec62ad83e8382e6036170d873f46e4536a7e795bf8b95bf7c247f4cc0825ccc8c17
   languageName: node
   linkType: hard
 
@@ -1033,35 +783,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-binary-path@npm:~2.1.0":
-  version: 2.1.0
-  resolution: "is-binary-path@npm:2.1.0"
-  dependencies:
-    binary-extensions: "npm:^2.0.0"
-  checksum: 10c0/a16eaee59ae2b315ba36fad5c5dcaf8e49c3e27318f8ab8fa3cdb8772bf559c8d1ba750a589c2ccb096113bb64497084361a25960899cb6172a6925ab6123d38
-  languageName: node
-  linkType: hard
-
-"is-extglob@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "is-extglob@npm:2.1.1"
-  checksum: 10c0/5487da35691fbc339700bbb2730430b07777a3c21b9ebaecb3072512dfd7b4ba78ac2381a87e8d78d20ea08affb3f1971b4af629173a6bf435ff8a4c47747912
-  languageName: node
-  linkType: hard
-
 "is-fullwidth-code-point@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
   checksum: 10c0/bb11d825e049f38e04c06373a8d72782eee0205bda9d908cc550ccb3c59b99d750ff9537982e01733c1c94a58e35400661f57042158ff5e8f3e90cf936daf0fc
-  languageName: node
-  linkType: hard
-
-"is-glob@npm:^4.0.1, is-glob@npm:~4.0.1":
-  version: 4.0.3
-  resolution: "is-glob@npm:4.0.3"
-  dependencies:
-    is-extglob: "npm:^2.1.1"
-  checksum: 10c0/17fb4014e22be3bbecea9b2e3a76e9e34ff645466be702f1693e8f1ee1adac84710d0be0bd9f967d6354036fd51ab7c2741d954d6e91dae6bb69714de92c197a
   languageName: node
   linkType: hard
 
@@ -1076,13 +801,6 @@ __metadata:
   version: 1.0.1
   resolution: "is-obj@npm:1.0.1"
   checksum: 10c0/5003acba0af7aa47dfe0760e545a89bbac89af37c12092c3efadc755372cdaec034f130e7a3653a59eb3c1843cfc72ca71eaf1a6c3bafe5a0bab3611a47f9945
-  languageName: node
-  linkType: hard
-
-"is-plain-obj@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "is-plain-obj@npm:2.1.0"
-  checksum: 10c0/e5c9814cdaa627a9ad0a0964ded0e0491bfd9ace405c49a5d63c88b30a162f1512c069d5b80997893c4d0181eadc3fed02b4ab4b81059aba5620bfcdfdeb9c53
   languageName: node
   linkType: hard
 
@@ -1121,28 +839,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isexe@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "isexe@npm:4.0.0"
-  checksum: 10c0/5884815115bceac452877659a9c7726382531592f43dc29e5d48b7c4100661aed54018cb90bd36cb2eaeba521092570769167acbb95c18d39afdccbcca06c5ce
-  languageName: node
-  linkType: hard
-
 "js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
   checksum: 10c0/e248708d377aa058eacf2037b07ded847790e6de892bbad3dac0abba2e759cb9f121b00099a65195616badcb6eca8d14d975cb3e89eb1cfda644756402c8aeed
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.1.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
   languageName: node
   linkType: hard
 
@@ -1226,15 +926,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"locate-path@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "locate-path@npm:6.0.0"
-  dependencies:
-    p-locate: "npm:^5.0.0"
-  checksum: 10c0/d3972ab70dfe58ce620e64265f90162d247e87159b6126b01314dd67be43d50e96a50b517bce2d9452a79409c7614054c277b5232377de50416564a77ac7aad3
-  languageName: node
-  linkType: hard
-
 "lodash.get@npm:^4.4.2":
   version: 4.4.2
   resolution: "lodash.get@npm:4.4.2"
@@ -1249,7 +940,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"log-symbols@npm:^4.0.0, log-symbols@npm:^4.1.0":
+"log-symbols@npm:^4.0.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
   dependencies:
@@ -1268,15 +959,6 @@ __metadata:
     slice-ansi: "npm:^4.0.0"
     wrap-ansi: "npm:^6.2.0"
   checksum: 10c0/18b299e230432a156f2535660776406d15ba8bb7817dd3eaadd58004b363756d4ecaabcd658f9949f90b62ea7d3354423be3fdeb7a201ab951ec0e8d6139af86
-  languageName: node
-  linkType: hard
-
-"loupe@npm:^2.3.6":
-  version: 2.3.7
-  resolution: "loupe@npm:2.3.7"
-  dependencies:
-    get-func-name: "npm:^2.0.1"
-  checksum: 10c0/71a781c8fc21527b99ed1062043f1f2bb30bdaf54fa4cf92463427e1718bc6567af2988300bc243c1f276e4f0876f29e3cbf7b58106fdc186915687456ce5bf4
   languageName: node
   linkType: hard
 
@@ -1313,62 +995,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^5.0.1, minimatch@npm:^5.1.6":
-  version: 5.1.9
-  resolution: "minimatch@npm:5.1.9"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/4202718683815a7288b13e470160a4f9560cf392adef4f453927505817e01ef6b3476ecde13cfcaed17e7326dd3b69ad44eb2daeb19a217c5500f9277893f1d6
-  languageName: node
-  linkType: hard
-
-"minipass@npm:^7.0.4, minipass@npm:^7.1.2":
-  version: 7.1.3
-  resolution: "minipass@npm:7.1.3"
-  checksum: 10c0/539da88daca16533211ea5a9ee98dc62ff5742f531f54640dd34429e621955e91cc280a91a776026264b7f9f6735947629f920944e9c1558369e8bf22eb33fbb
-  languageName: node
-  linkType: hard
-
-"minizlib@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "minizlib@npm:3.1.0"
-  dependencies:
-    minipass: "npm:^7.1.2"
-  checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
-  languageName: node
-  linkType: hard
-
-"mocha@npm:^10.8.2":
-  version: 10.8.2
-  resolution: "mocha@npm:10.8.2"
-  dependencies:
-    ansi-colors: "npm:^4.1.3"
-    browser-stdout: "npm:^1.3.1"
-    chokidar: "npm:^3.5.3"
-    debug: "npm:^4.3.5"
-    diff: "npm:^5.2.0"
-    escape-string-regexp: "npm:^4.0.0"
-    find-up: "npm:^5.0.0"
-    glob: "npm:^8.1.0"
-    he: "npm:^1.2.0"
-    js-yaml: "npm:^4.1.0"
-    log-symbols: "npm:^4.1.0"
-    minimatch: "npm:^5.1.6"
-    ms: "npm:^2.1.3"
-    serialize-javascript: "npm:^6.0.2"
-    strip-json-comments: "npm:^3.1.1"
-    supports-color: "npm:^8.1.1"
-    workerpool: "npm:^6.5.1"
-    yargs: "npm:^16.2.0"
-    yargs-parser: "npm:^20.2.9"
-    yargs-unparser: "npm:^2.0.0"
-  bin:
-    _mocha: bin/_mocha
-    mocha: bin/mocha.js
-  checksum: 10c0/1f786290a32a1c234f66afe2bfcc68aa50fe9c7356506bd39cca267efb0b4714a63a0cb333815578d63785ba2fba058bf576c2512db73997c0cae0d659a88beb
-  languageName: node
-  linkType: hard
-
 "ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -1389,38 +1015,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:latest":
-  version: 13.0.0
-  resolution: "node-gyp@npm:13.0.0"
-  dependencies:
-    env-paths: "npm:^2.2.0"
-    exponential-backoff: "npm:^3.1.1"
-    graceful-fs: "npm:^4.2.6"
-    nopt: "npm:^10.0.0"
-    proc-log: "npm:^7.0.0"
-    semver: "npm:^7.3.5"
-    tar: "npm:^7.5.4"
-    tinyglobby: "npm:^0.2.12"
-    undici: "npm:^6.25.0"
-    which: "npm:^7.0.0"
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: 10c0/e7525c427db2d16aa368b8947187de83083d2a8dda23e3e096a71c22ae637ac5bb8ed7cf6c871f1b9118cd2729dbfee4ff3a4245e2b79226900227b15831b492
-  languageName: node
-  linkType: hard
-
-"nopt@npm:^10.0.0":
-  version: 10.0.1
-  resolution: "nopt@npm:10.0.1"
-  dependencies:
-    abbrev: "npm:^5.0.0"
-  bin:
-    nopt: bin/nopt.js
-  checksum: 10c0/980d89257f9587f3e1f77877ddbf905d6aa3b738ec33e49a4fa1a059a0dd82eb28063982b150654a7ae9de386f2ead60e56172db7d37cf56de545f7392a2a26a
-  languageName: node
-  linkType: hard
-
-"normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
+"normalize-path@npm:^3.0.0":
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: 10c0/e008c8142bcc335b5e38cf0d63cfd39d6cf2d97480af9abdbe9a439221fd4d749763bab492a8ee708ce7a194bb00c9da6d0a115018672310850489137b3da046
@@ -1530,24 +1125,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^3.0.2":
-  version: 3.1.0
-  resolution: "p-limit@npm:3.1.0"
-  dependencies:
-    yocto-queue: "npm:^0.1.0"
-  checksum: 10c0/9db675949dbdc9c3763c89e748d0ef8bdad0afbb24d49ceaf4c46c02c77d30db4e0652ed36d0a0a7a95154335fab810d95c86153105bb73b3a90448e2bb14e1a
-  languageName: node
-  linkType: hard
-
-"p-locate@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "p-locate@npm:5.0.0"
-  dependencies:
-    p-limit: "npm:^3.0.2"
-  checksum: 10c0/2290d627ab7903b8b70d11d384fee714b797f6040d9278932754a6860845c4d3190603a0772a663c8cb5a7b21d1b16acb3a6487ebcafa9773094edc3dfe6009a
-  languageName: node
-  linkType: hard
-
 "p-map@npm:^4.0.0":
   version: 4.0.0
   resolution: "p-map@npm:4.0.0"
@@ -1587,13 +1164,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-exists@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "path-exists@npm:4.0.0"
-  checksum: 10c0/8c0bd3f5238188197dc78dced15207a4716c51cc4e3624c44fc97acf69558f5ebb9a2afff486fe1b4ee148e0c133e96c5e11a9aa5c48a3006e3467da070e5e1b
-  languageName: node
-  linkType: hard
-
 "path-is-absolute@npm:^1.0.0":
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
@@ -1622,13 +1192,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pathval@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "pathval@npm:1.1.1"
-  checksum: 10c0/f63e1bc1b33593cdf094ed6ff5c49c1c0dc5dc20a646ca9725cc7fe7cd9995002d51d5685b9b2ec6814342935748b711bafa840f84c0bb04e38ff40a335c94dc
-  languageName: node
-  linkType: hard
-
 "picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -1636,17 +1199,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.3.1":
   version: 2.3.2
   resolution: "picomatch@npm:2.3.2"
   checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "picomatch@npm:4.0.4"
-  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
   languageName: node
   linkType: hard
 
@@ -1656,13 +1212,6 @@ __metadata:
   dependencies:
     semver-compare: "npm:^1.0.0"
   checksum: 10c0/222514d2841022be4b843f38d415beadcc6409c0545d6d153778d71c601bba7bbf1cd5827d650c7fae6a9a2ba7cf00f4b6729b40d015a3a5ba2937e57bc1c435
-  languageName: node
-  linkType: hard
-
-"proc-log@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "proc-log@npm:7.0.0"
-  checksum: 10c0/b89c2d862604f35fec795477b0c7e376feab3ba0d4f4d291c4e959567442697cf451ac557d0623c1cc38af45a78128b983410f397a10c5d3a67f76c33de4754b
   languageName: node
   linkType: hard
 
@@ -1683,31 +1232,6 @@ __metadata:
     end-of-stream: "npm:^1.1.0"
     once: "npm:^1.3.1"
   checksum: 10c0/2780e66b5471c19e3e3e1063b84f3f6a3a08367f24c5ed552f98cd5901e6ada27c7ad6495d4244f553fd03b01884a4561933064f053f47c8994d84fd352768ea
-  languageName: node
-  linkType: hard
-
-"randombytes@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "randombytes@npm:2.1.0"
-  dependencies:
-    safe-buffer: "npm:^5.1.0"
-  checksum: 10c0/50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
-  languageName: node
-  linkType: hard
-
-"readdirp@npm:~3.6.0":
-  version: 3.6.0
-  resolution: "readdirp@npm:3.6.0"
-  dependencies:
-    picomatch: "npm:^2.2.1"
-  checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
-  languageName: node
-  linkType: hard
-
-"require-directory@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "require-directory@npm:2.1.1"
-  checksum: 10c0/83aa76a7bc1531f68d92c75a2ca2f54f1b01463cb566cf3fbc787d0de8be30c9dbc211d1d46be3497dac5785fe296f2dd11d531945ac29730643357978966e99
   languageName: node
   linkType: hard
 
@@ -1751,13 +1275,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:^5.1.0":
-  version: 5.2.1
-  resolution: "safe-buffer@npm:5.2.1"
-  checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
-  languageName: node
-  linkType: hard
-
 "semver-compare@npm:^1.0.0":
   version: 1.0.0
   resolution: "semver-compare@npm:1.0.0"
@@ -1765,21 +1282,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.1.1, semver@npm:^7.3.5":
+"semver@npm:^7.1.1":
   version: 7.8.4
   resolution: "semver@npm:7.8.4"
   bin:
     semver: bin/semver.js
   checksum: 10c0/81b7c296fd7927b80f67fa516b75fa1017caac8167795320de28e76ccbc6f7f01763c30ecd10d6a0d8fd089708ab0548a5aebb94b0870e99c2a2b4600a46389b
-  languageName: node
-  linkType: hard
-
-"serialize-javascript@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "serialize-javascript@npm:6.0.2"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 10c0/2dd09ef4b65a1289ba24a788b1423a035581bef60817bea1f01eda8e3bda623f86357665fe7ac1b50f6d4f583f97db9615b3f07b2a2e8cbcb75033965f771dd2
   languageName: node
   linkType: hard
 
@@ -1907,13 +1415,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-json-comments@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "strip-json-comments@npm:3.1.1"
-  checksum: 10c0/9681a6257b925a7fa0f285851c0e613cc934a50661fa7bb41ca9cbbff89686bb4a0ee366e6ecedc4daafd01e83eee0720111ab294366fe7c185e935475ebcecd
-  languageName: node
-  linkType: hard
-
 "supports-color@npm:^7.1.0, supports-color@npm:^7.2.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
@@ -1923,42 +1424,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^8.1.1":
-  version: 8.1.1
-  resolution: "supports-color@npm:8.1.1"
-  dependencies:
-    has-flag: "npm:^4.0.0"
-  checksum: 10c0/ea1d3c275dd604c974670f63943ed9bd83623edc102430c05adb8efc56ba492746b6e95386e7831b872ec3807fd89dd8eb43f735195f37b5ec343e4234cc7e89
-  languageName: node
-  linkType: hard
-
-"tar@npm:^7.5.4":
-  version: 7.5.16
-  resolution: "tar@npm:7.5.16"
-  dependencies:
-    "@isaacs/fs-minipass": "npm:^4.0.0"
-    chownr: "npm:^3.0.0"
-    minipass: "npm:^7.1.2"
-    minizlib: "npm:^3.1.0"
-    yallist: "npm:^5.0.0"
-  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
-  languageName: node
-  linkType: hard
-
 "through@npm:^2.3.8":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
-  languageName: node
-  linkType: hard
-
-"tinyglobby@npm:^0.2.12":
-  version: 0.2.17
-  resolution: "tinyglobby@npm:0.2.17"
-  dependencies:
-    fdir: "npm:^6.5.0"
-    picomatch: "npm:^4.0.4"
-  checksum: 10c0/7f7bb0f197c88bc4b20c231e0deca4240ca3bf313a88f5a7fee93a872b84966a4d50220947c0455ad07a60b3b360961c5b7fd979222aeb716a9f99b412002e4c
   languageName: node
   linkType: hard
 
@@ -2001,7 +1470,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-detect@npm:^4.0.0, type-detect@npm:^4.0.8, type-detect@npm:^4.1.0":
+"type-detect@npm:^4.0.8":
   version: 4.1.0
   resolution: "type-detect@npm:4.1.0"
   checksum: 10c0/df8157ca3f5d311edc22885abc134e18ff8ffbc93d6a9848af5b682730ca6a5a44499259750197250479c5331a8a75b5537529df5ec410622041650a7f293e2a
@@ -2019,13 +1488,6 @@ __metadata:
   version: 7.24.6
   resolution: "undici-types@npm:7.24.6"
   checksum: 10c0/d9cd8befb643ac904615c280a095ba4240531f6bb4a5e75a22a7483630ca8d3f1016d2ab6ace6ceda1f63b3a2db2fe037fafe121d6917a0187573aa548ff78ca
-  languageName: node
-  linkType: hard
-
-"undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
   languageName: node
   linkType: hard
 
@@ -2058,28 +1520,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "which@npm:7.0.0"
-  dependencies:
-    isexe: "npm:^4.0.0"
-  bin:
-    node-which: bin/which.js
-  checksum: 10c0/ca0b54f198f78bbc4b7c02e34bda8d335cb352e0adb4cbca1c37b1a957af3a879a82c4c27ca6525bc942f548d8b64f816ef6528360af9f3de55ffb9b979b620d
-  languageName: node
-  linkType: hard
-
 "word-wrap@npm:^1.2.4":
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
   checksum: 10c0/e0e4a1ca27599c92a6ca4c32260e8a92e8a44f4ef6ef93f803f8ed823f486e0889fc0b93be4db59c8d51b3064951d25e43d434e95dc8c960cc3a63d65d00ba20
-  languageName: node
-  linkType: hard
-
-"workerpool@npm:^6.5.1":
-  version: 6.5.1
-  resolution: "workerpool@npm:6.5.1"
-  checksum: 10c0/58e8e969782292cb3a7bfba823f1179a7615250a0cefb4841d5166234db1880a3d0fe83a31dd8d648329ec92c2d0cd1890ad9ec9e53674bb36ca43e9753cdeac
   languageName: node
   linkType: hard
 
@@ -2130,13 +1574,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yallist@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "yallist@npm:5.0.0"
-  checksum: 10c0/a499c81ce6d4a1d260d4ea0f6d49ab4da09681e32c3f0472dee16667ed69d01dae63a3b81745a24bd78476ec4fcf856114cb4896ace738e01da34b2c42235416
-  languageName: node
-  linkType: hard
-
 "yaml@npm:^1.10.0":
   version: 1.10.3
   resolution: "yaml@npm:1.10.3"
@@ -2144,44 +1581,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.9":
-  version: 20.2.9
-  resolution: "yargs-parser@npm:20.2.9"
-  checksum: 10c0/0685a8e58bbfb57fab6aefe03c6da904a59769bd803a722bb098bd5b0f29d274a1357762c7258fb487512811b8063fb5d2824a3415a0a4540598335b3b086c72
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:^22.0.0":
   version: 22.0.0
   resolution: "yargs-parser@npm:22.0.0"
   checksum: 10c0/cb7ef81759c4271cb1d96b9351dbbc9a9ce35d3e1122d2b739bf6c432603824fa02c67cc12dcef6ea80283379d63495686e8f41cc7b06c6576e792aba4d33e1c
-  languageName: node
-  linkType: hard
-
-"yargs-unparser@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "yargs-unparser@npm:2.0.0"
-  dependencies:
-    camelcase: "npm:^6.0.0"
-    decamelize: "npm:^4.0.0"
-    flat: "npm:^5.0.2"
-    is-plain-obj: "npm:^2.1.0"
-  checksum: 10c0/a5a7d6dc157efa95122e16780c019f40ed91d4af6d2bac066db8194ed0ec5c330abb115daa5a79ff07a9b80b8ea80c925baacf354c4c12edd878c0529927ff03
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^16.2.0":
-  version: 16.2.0
-  resolution: "yargs@npm:16.2.0"
-  dependencies:
-    cliui: "npm:^7.0.2"
-    escalade: "npm:^3.1.1"
-    get-caller-file: "npm:^2.0.5"
-    require-directory: "npm:^2.1.1"
-    string-width: "npm:^4.2.0"
-    y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^20.2.2"
-  checksum: 10c0/b1dbfefa679848442454b60053a6c95d62f2d2e21dd28def92b647587f415969173c6e99a0f3bab4f1b67ee8283bf735ebe3544013f09491186ba9e8a9a2b651
   languageName: node
   linkType: hard
 
@@ -2196,12 +1599,5 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^22.0.0"
   checksum: 10c0/bf290e4723876ea9c638c786a5c42ac28e03c9ca2325e1424bf43b94e5876456292d3ed905b853ebbba6daf43ed29e772ac2a6b3c5fb1b16533245d6211778f3
-  languageName: node
-  linkType: hard
-
-"yocto-queue@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "yocto-queue@npm:0.1.0"
-  checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
   languageName: node
   linkType: hard


### PR DESCRIPTION
Converts the package to an ES module and migrates the test suite from mocha to the built-in `node:test` runner, mirroring electron-userland/electron-installer-debian#368.

**ESM conversion (breaking)**
- `"type": "module"` with `"exports": "./src/installer.js"`; all of `src/` and `test/` use `import`/`export`, `__dirname` becomes `import.meta.dirname`, and the CLI reads `package.json` via `readFileSync`.
- The API is now a default export plus a named `Installer` export. CommonJS consumers on Node.js >= 22.12 can still load it with `require('electron-installer-redhat').default`.
- README and NEWS updated accordingly.

**Test changes**
- mocha is replaced by `node --test` (no default timeouts needed, built-in coverage available via `yarn coverage`); assertions stay on chai, bumped to the zero-dependency v6.
- `proxyquire` and `chai-as-promised` are removed: proxyquire cannot intercept ES module imports. The RPM version-parsing tests now exercise a small `parseRpmVersionOutput` helper on the dependencies object directly, plus a real `rpmbuild --version` integration test, and the promise assertions use `node:assert`'s `rejects`/`doesNotReject`. `sinon` stays for stubbing.

Verified locally on Linux with rpmbuild/rpmlint installed: lint clean and all 27 tests pass, building real RPMs.